### PR TITLE
ci: add test with pebble workflow

### DIFF
--- a/.github/workflows/_test-with-pebble.yaml
+++ b/.github/workflows/_test-with-pebble.yaml
@@ -1,13 +1,16 @@
-name: "Node: Build + Integration"
+name: Test With Pebble
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_call:
+    inputs:
+      test_command:
+        type: string
+        description: "The test command to run"
+        required: true
+        default: "deno task test:integration"
 
 jobs:
-  test:
+  test-with-pebble:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -23,24 +26,21 @@ jobs:
       - name: Wait for Pebble to be ready
         run: |
           echo "⏳ Waiting for Pebble... 🪨"
-
-          # Loop until the port 14000 is open
           until nc -zv localhost 14000 2>/dev/null; do
             sleep 1
           done
-
           echo "✅ Pebble is running!"
+
       - name: Wait for pebble-challtestsrv to be ready
         run: |
           echo "⏳ Waiting for pebble-challtestsrv... 🪨"
-
           until nc -zv localhost 8055 2>/dev/null; do
             sleep 1
           done
-
           echo "✅ pebble-challtestsrv is running!"
 
-      - run: deno task build:npm:integration
+      # Run the test command passed from the calling workflow
+      - run: ${{ inputs.test_command }}
 
       - name: Stop Pebble
         run: deno task pebble:stop

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,40 +7,13 @@ on:
   pull_request:
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x # Run with latest stable Deno.
-
-      - name: Start Pebble and pebble-challtestsrv
-        run: deno task pebble:start --detach
-
-      - name: Wait for Pebble to be ready
-        run: |
-          echo "⏳ Waiting for Pebble... 🪨"
-
-          # Loop until the port 14000 is open
-          until nc -zv localhost 14000 2>/dev/null; do
-            sleep 1
-          done
-
-          echo "✅ Pebble is running!"
-      - name: Wait for pebble-challtestsrv to be ready
-        run: |
-          echo "⏳ Waiting for pebble-challtestsrv... 🪨"
-
-          until nc -zv localhost 8055 2>/dev/null; do
-            sleep 1
-          done
-
-          echo "✅ pebble-challtestsrv is running!"
-
-      - run: deno task test:integration
-
-      - name: Stop Pebble
-        run: deno task pebble:stop
+  deno:
+    name: Deno
+    uses: ./.github/workflows/_test-with-pebble.yaml
+    with:
+      test_command: deno task test:integration
+  node:
+    name: Node
+    uses: ./.github/workflows/_test-with-pebble.yaml
+    with:
+      test_command: deno task build:npm:integration


### PR DESCRIPTION
This avoid redefining steps to run pebble for integration tests.