### PR TITLE
chore: add Sponsor button (FUNDING.yml)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: ycmjason


### PR DESCRIPTION
Adds `.github/FUNDING.yml` (`github: ycmjason`) so GitHub renders a **Sponsor** button on the repo.

The button only renders from the config on the default branch, so this targets `main` directly (separate from the in-flight feature PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)