### PR TITLE
feat: RSA certificate key pairs via per-key algorithm strategy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   fmt-lint-check:
     name: "Format & Lint & Type Check"
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
@@ -20,7 +20,7 @@ jobs:
       - run: deno check --doc .
   deno-unit:
     name: "Unit Test (Deno)"
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
@@ -29,7 +29,7 @@ jobs:
       - run: deno task test:unit
   node-unit:
     name: "Unit Test (Node.js)"
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'e2e:approve' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   deno:
     name: Deno
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
 
@@ -23,7 +23,7 @@ jobs:
       - run: deno task test:integration
   node:
     name: Node
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-jsr:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     permissions:
       contents: read
@@ -19,7 +19,7 @@ jobs:
         run: npx jsr publish
 
   publish-npm:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ key features:
 - **Opinionated by Design**: The package is designed to work out of the box,
   with no complex setup required.
   - Modern cryptography: Encryption keys are generated using [ECDSA P-256], a
-    secure, widely supported industry standard.
+    secure, widely supported industry standard. RSA (2048/4096) is available for
+    environments that require it (see
+    [`keyPairAlgorithm`](#rsa-keys-keypairalgorithm)).
   - [DNS-01 Challenge] only: We focus on the DNS-01 challenge type, which we
     believe is the most versatile. It works for all services, supports wildcard
     certificates, and eliminates complex server configurations by operating at

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ await AcmeWorkflows.requestCertificate({
   - [ ] Revocation
 - [x] Key and Algorithm Support
   - [x] ECDSA P-256
-  - [ ] ~~RSA~~
+  - [x] RSA (2048/4096)
 - [x] ACME Server Interaction
   - [x] ACME Directory Support (staging, production)
   - [x] Bad Nonce Retries

--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ any request is made.
 
 #### RSA keys (`keyPairAlgorithm`)
 
-Keys default to ECDSA P-256 (`"ec"`). To use RSA instead — for the account key
-and every certificate key minted from this account — pass `keyPairAlgorithm`:
+Keys default to ECDSA P-256 (`"ec-p256"`). To use RSA instead — for the account
+key and every certificate key minted from this account — pass
+`keyPairAlgorithm`:
 
 ```ts
 const account = await acmeClient.createAccount({

--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ CA's directory advertises `meta.externalAccountRequired`, calling
 `createAccount` without an `externalAccountBinding` throws immediately — before
 any request is made.
 
+#### RSA keys (`keyPairAlgorithm`)
+
+Keys default to ECDSA P-256 (`"ec"`). To use RSA instead — for the account key
+and every certificate key minted from this account — pass `keyPairAlgorithm`:
+
+```ts
+const account = await acmeClient.createAccount({
+  emails: ["yo@fishball.app"],
+  keyPairAlgorithm: "rsa-2048", // or "rsa-4096"
+});
+```
+
+When you `login` with a saved key pair (or import one with
+`CryptoKeyUtils.importKeyPairFromPemPrivateKey`), there is nothing extra to pass
+— the algorithm is detected from the key itself.
+
 ### 0x03: Create order and get the challenges
 
 ```ts

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishballpkg/acme",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "exports": {
     ".": "./src/mod.ts",
     "./DnsUtils": "./src/DnsUtils/mod.ts",

--- a/integration/workflows.test.ts
+++ b/integration/workflows.test.ts
@@ -57,4 +57,34 @@ describe("requestCertificates", () => {
     expect(notBefore.getTime()).toBeLessThan(Date.now());
     expect(notAfter.getTime()).toBeGreaterThan(Date.now());
   });
+
+  it("should successfully get certs with an RSA account", async () => {
+    const client = await AcmeClient.init(PEBBLE_DIRECTORY_URL);
+
+    const acmeAccount = await client.createAccount({
+      emails: [generateRandomEmail()],
+      keyPairAlgorithm: "rsa-2048",
+    });
+
+    expect(acmeAccount.keyPair.privateKey.algorithm.name).toBe(
+      "RSASSA-PKCS1-v1_5",
+    );
+
+    const { certificate, certKeyPair } = await AcmeWorkflows
+      .requestCertificate({
+        acmeAccount,
+        domains: [generateRandomDomain()],
+        updateDnsRecords: async (dnsRecords) => {
+          await pebbleChallTestSrv.createDnsRecords(dnsRecords);
+        },
+        resolveDns,
+      });
+
+    // The certificate key follows the account's keyPairAlgorithm.
+    expect(certKeyPair.privateKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");
+
+    const { notBefore, notAfter } = CertUtils.decodeValidity(certificate);
+    expect(notBefore.getTime()).toBeLessThan(Date.now());
+    expect(notAfter.getTime()).toBeGreaterThan(Date.now());
+  });
 });

--- a/src/AcmeAccount.ts
+++ b/src/AcmeAccount.ts
@@ -168,6 +168,7 @@ export class AcmeAccount {
       client: this.client,
       url: this.url,
       keyPair: newKeyPair,
+      keyPairAlgorithm: this.keyPairAlgorithm,
     });
   }
 

--- a/src/AcmeAccount.ts
+++ b/src/AcmeAccount.ts
@@ -1,6 +1,6 @@
 import type { AcmeClient } from "./AcmeClient.ts";
 import { AcmeOrder, type AcmeOrderObjectSnapshot } from "./AcmeOrder.ts";
-import { generateKeyPair } from "./utils/crypto.ts";
+import { generateKeyPair, type KeyPairAlgorithm } from "./utils/crypto.ts";
 import { emailsToAccountContacts } from "./utils/emailsToAccountContacts.ts";
 import { jws } from "./utils/jws.ts";
 import { AcmeError } from "./errors.ts";
@@ -54,6 +54,7 @@ export type AcmeAccountObjectSnapshot = {
 export class AcmeAccount {
   readonly client: AcmeClient;
   readonly keyPair: CryptoKeyPair;
+  readonly keyPairAlgorithm?: KeyPairAlgorithm;
   readonly url: string;
 
   /**
@@ -67,10 +68,12 @@ export class AcmeAccount {
   constructor(init: {
     client: AcmeClient;
     keyPair: CryptoKeyPair;
+    keyPairAlgorithm?: KeyPairAlgorithm;
     url: string;
   }) {
     this.client = init.client;
     this.keyPair = init.keyPair;
+    this.keyPairAlgorithm = init.keyPairAlgorithm;
     this.url = init.url;
   }
 
@@ -132,7 +135,7 @@ export class AcmeAccount {
    */
   async keyRollover(): Promise<AcmeAccount> {
     const [newKeyPair, oldPublicKeyJwk] = await Promise.all([
-      generateKeyPair(),
+      generateKeyPair(this.keyPairAlgorithm),
       crypto.subtle.exportKey(
         "jwk",
         this.keyPair.publicKey,

--- a/src/AcmeAccount.ts
+++ b/src/AcmeAccount.ts
@@ -54,6 +54,13 @@ export type AcmeAccountObjectSnapshot = {
 export class AcmeAccount {
   readonly client: AcmeClient;
   readonly keyPair: CryptoKeyPair;
+  /**
+   * The algorithm used to generate keys for this account — the certificate
+   * keys minted by {@link AcmeOrder.prototype.finalize} and the new key on
+   * {@link AcmeAccount.prototype.keyRollover}. Defaults to `"ec-p256"` when
+   * the account was created without specifying one; `undefined` when it was
+   * derived from a `login` key pair that falls outside the supported set.
+   */
   readonly keyPairAlgorithm?: KeyPairAlgorithm;
   readonly url: string;
 
@@ -132,6 +139,7 @@ export class AcmeAccount {
    *
    * After rollover, you will receive a new {@link AcmeAccount} object.
    * You may access to the new key pair via `{@link AcmeAccount.prototype.keyPair}.
+   * The new key uses this account's {@link AcmeAccount.prototype.keyPairAlgorithm}.
    */
   async keyRollover(): Promise<AcmeAccount> {
     const [newKeyPair, oldPublicKeyJwk] = await Promise.all([

--- a/src/AcmeChallenge.test.ts
+++ b/src/AcmeChallenge.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "../test_deps.ts";
 import { encodeBase64Url as stdEncodeBase64Url } from "../test_deps.ts";
 import { AcmeChallenge, type AcmeChallengeType } from "./AcmeChallenge.ts";
 import type { AcmeAuthorization } from "./AcmeAuthorization.ts";
-import { generateKeyPair } from "./utils/crypto.ts";
+import { generateKeyPair, type KeyPairAlgorithm } from "./utils/crypto.ts";
 
 const TOKEN = "test-token-abc123";
 const DOMAIN = "example.com";
@@ -15,8 +15,9 @@ const DOMAIN = "example.com";
  */
 const buildChallenge = async <const T extends AcmeChallengeType>(
   type: T,
+  keyPairAlgorithm?: KeyPairAlgorithm,
 ): Promise<{ challenge: AcmeChallenge<T>; keyPair: CryptoKeyPair }> => {
-  const keyPair = await generateKeyPair();
+  const keyPair = await generateKeyPair(keyPairAlgorithm);
   const authorization = {
     domain: DOMAIN,
     order: { account: { keyPair } },
@@ -37,12 +38,12 @@ const expectedKeyAuthorization = async (
   keyPair: CryptoKeyPair,
 ): Promise<string> => {
   const jwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
-  const canonical = JSON.stringify({
-    crv: jwk.crv,
-    kty: jwk.kty,
-    x: jwk.x,
-    y: jwk.y,
-  });
+  // RFC 7638 §3.2: only the key type's required members, sorted.
+  const canonical = JSON.stringify(
+    jwk.kty === "RSA"
+      ? { e: jwk.e, kty: jwk.kty, n: jwk.n }
+      : { crv: jwk.crv, kty: jwk.kty, x: jwk.x, y: jwk.y },
+  );
   const thumbprint = stdEncodeBase64Url(
     await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical)),
   );
@@ -55,6 +56,23 @@ describe("AcmeChallenge#keyAuthorization", () => {
     expect(await challenge.keyAuthorization()).toBe(
       await expectedKeyAuthorization(keyPair),
     );
+  });
+
+  it("uses the RSA thumbprint members (e, kty, n) for RSA account keys (RFC 7638 §3.2)", async () => {
+    const { challenge, keyPair } = await buildChallenge("dns-01", "rsa-2048");
+
+    const keyAuthorization = await challenge.keyAuthorization();
+
+    expect(keyAuthorization).toBe(await expectedKeyAuthorization(keyPair));
+    // Guard against hashing `{"kty":"RSA"}` — the canonicalization that EC's
+    // members (crv, x, y) would produce on an RSA JWK.
+    const wrongThumbprint = stdEncodeBase64Url(
+      await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(JSON.stringify({ kty: "RSA" })),
+      ),
+    );
+    expect(keyAuthorization).not.toBe(`${TOKEN}.${wrongThumbprint}`);
   });
 
   it("digestToken is the base64url SHA-256 of the key authorization (dns-01, §8.4)", async () => {

--- a/src/AcmeChallenge.ts
+++ b/src/AcmeChallenge.ts
@@ -244,13 +244,22 @@ export class AcmeChallenge<
 }
 
 async function getJWKThumbprint(jwk: JsonWebKey): Promise<string> {
-  // Step 1: Create the canonical JSON string from required JWK fields,
-  const canonicalJWK = JSON.stringify({
-    crv: jwk.crv,
-    kty: jwk.kty,
-    x: jwk.x,
-    y: jwk.y,
-  });
+  // Step 1: Create the canonical JSON string from required JWK fields.
+  // RFC 7638 §3.2: hash ONLY the required members of the key type, in
+  // lexicographic order (JSON.stringify preserves the literal's member
+  // order, so each literal below is spelled pre-sorted).
+  const canonicalJWK = JSON.stringify((() => {
+    switch (jwk.kty) {
+      case "EC":
+        return { crv: jwk.crv, kty: jwk.kty, x: jwk.x, y: jwk.y };
+      case "RSA":
+        return { e: jwk.e, kty: jwk.kty, n: jwk.n };
+      default:
+        throw new Error(
+          `Unsupported JWK key type "${jwk.kty}" for thumbprint. Expected "EC" or "RSA".`,
+        );
+    }
+  })());
 
   // Step 2: Hash the canonical JSON using SHA-256
   const hash = await crypto.subtle.digest(

--- a/src/AcmeChallenge.ts
+++ b/src/AcmeChallenge.ts
@@ -243,23 +243,28 @@ export class AcmeChallenge<
   }
 }
 
+/**
+ * The required JWK members each key type hashes into its thumbprint
+ * (RFC 7638 §3.2), in lexicographic order — `JSON.stringify` preserves the
+ * literals' member order, so each is spelled pre-sorted.
+ */
+const THUMBPRINT_JWK_MEMBERS_BY_KTY: Record<
+  string,
+  (jwk: JsonWebKey) => Record<string, string | undefined>
+> = {
+  EC: ({ crv, kty, x, y }) => ({ crv, kty, x, y }),
+  RSA: ({ e, kty, n }) => ({ e, kty, n }),
+};
+
 async function getJWKThumbprint(jwk: JsonWebKey): Promise<string> {
   // Step 1: Create the canonical JSON string from required JWK fields.
-  // RFC 7638 §3.2: hash ONLY the required members of the key type, in
-  // lexicographic order (JSON.stringify preserves the literal's member
-  // order, so each literal below is spelled pre-sorted).
-  const canonicalJWK = JSON.stringify((() => {
-    switch (jwk.kty) {
-      case "EC":
-        return { crv: jwk.crv, kty: jwk.kty, x: jwk.x, y: jwk.y };
-      case "RSA":
-        return { e: jwk.e, kty: jwk.kty, n: jwk.n };
-      default:
-        throw new Error(
-          `Unsupported JWK key type "${jwk.kty}" for thumbprint. Expected "EC" or "RSA".`,
-        );
-    }
-  })());
+  const pickThumbprintMembers = THUMBPRINT_JWK_MEMBERS_BY_KTY[jwk.kty ?? ""];
+  if (pickThumbprintMembers === undefined) {
+    throw new Error(
+      `Unsupported JWK key type "${jwk.kty}" for thumbprint. Expected "EC" or "RSA".`,
+    );
+  }
+  const canonicalJWK = JSON.stringify(pickThumbprintMembers(jwk));
 
   // Step 2: Hash the canonical JSON using SHA-256
   const hash = await crypto.subtle.digest(

--- a/src/AcmeClient.test.ts
+++ b/src/AcmeClient.test.ts
@@ -4,7 +4,7 @@ import {
   encodeBase64Url as stdEncodeBase64Url,
 } from "../test_deps.ts";
 import { AcmeClient } from "./AcmeClient.ts";
-import { importHmacKey } from "./utils/crypto.ts";
+import { generateKeyPair, importHmacKey } from "./utils/crypto.ts";
 
 type MockFetch = (
   ...args: Parameters<typeof fetch>
@@ -170,6 +170,49 @@ describe("AcmeClient#createAccount with externalAccountBinding", () => {
     });
 
     expect(newAccountCalled).toBe(false);
+  });
+});
+
+describe("AcmeClient#login", () => {
+  it("derives keyPairAlgorithm from the key pair and signs with the matching alg", async () => {
+    let capturedBody: string | undefined;
+
+    const mockFetch: MockFetch = (input, init) => {
+      const url = input.toString();
+      const method = asInit(init).method ?? "GET";
+
+      if (url === DIRECTORY_URL) {
+        return Response.json(buildDirectory());
+      }
+      if (url === NEW_NONCE_URL) {
+        return new Response(null, {
+          headers: { "Replay-Nonce": "test-nonce" },
+        });
+      }
+      if (url === NEW_ACCOUNT_URL && method === "POST") {
+        capturedBody = asInit(init).body;
+        return Response.json({}, {
+          headers: { Location: "https://ca.test/account/123" },
+        });
+      }
+      throw new Error(`unexpected request: ${method} ${url}`);
+    };
+
+    await withMockFetch(mockFetch, async () => {
+      const client = await AcmeClient.init(DIRECTORY_URL);
+      const keyPair = await generateKeyPair("rsa-2048");
+
+      const account = await client.login({ keyPair });
+
+      // No keyPairAlgorithm was passed: it must be derived from the key, so
+      // certificate keys and key rollover keep using RSA.
+      expect(account.keyPairAlgorithm).toBe("rsa-2048");
+
+      const { protected: protectedB64 } = JSON.parse(capturedBody!) as {
+        protected: string;
+      };
+      expect(decodeJsonSegment(protectedB64).alg).toBe("RS256");
+    });
   });
 });
 

--- a/src/AcmeClient.ts
+++ b/src/AcmeClient.ts
@@ -7,7 +7,7 @@ import {
   AcmeError,
   BadNonceError,
 } from "./errors.ts";
-import { generateKeyPair, importHmacKey } from "./utils/crypto.ts";
+import { generateKeyPair, importHmacKey, type KeyPairAlgorithm } from "./utils/crypto.ts";
 import { emailsToAccountContacts } from "./utils/emailsToAccountContacts.ts";
 import { jws, jwsFetch } from "./utils/jws.ts";
 
@@ -139,7 +139,7 @@ export class AcmeClient {
 
     this.#nonceQueue.push(
       response.headers.get(REPLAY_NONCE_HEADER_KEY) ??
-        await this.#fetchNonce(),
+      await this.#fetchNonce(),
     );
 
     if (!response.ok) {
@@ -184,9 +184,11 @@ export class AcmeClient {
     {
       emails,
       externalAccountBinding,
+      keyPairAlgorithm,
     }: {
       emails: readonly string[];
       externalAccountBinding?: ExternalAccountBinding;
+      keyPairAlgorithm?: KeyPairAlgorithm;
     },
   ): Promise<AcmeAccount> {
     if (
@@ -253,6 +255,7 @@ export class AcmeClient {
       client: this,
       url: accountUrl,
       keyPair,
+      keyPairAlgorithm,
     });
   }
 
@@ -261,7 +264,13 @@ export class AcmeClient {
    *
    * @see https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.1
    */
-  async login({ keyPair }: { keyPair: CryptoKeyPair }): Promise<AcmeAccount> {
+  async login({
+    keyPair,
+    keyPairAlgorithm,
+  }: {
+    keyPair: CryptoKeyPair;
+    keyPairAlgorithm?: KeyPairAlgorithm;
+  }): Promise<AcmeAccount> {
     const response = await this.jwsFetch(this.directory.newAccount, {
       privateKey: keyPair.privateKey,
       protected: {
@@ -298,6 +307,7 @@ export class AcmeClient {
       client: this,
       url: accountUrl,
       keyPair,
+      keyPairAlgorithm,
     });
   }
 }

--- a/src/AcmeClient.ts
+++ b/src/AcmeClient.ts
@@ -7,7 +7,11 @@ import {
   AcmeError,
   BadNonceError,
 } from "./errors.ts";
-import { generateKeyPair, importHmacKey, type KeyPairAlgorithm } from "./utils/crypto.ts";
+import {
+  generateKeyPair,
+  importHmacKey,
+  type KeyPairAlgorithm,
+} from "./utils/crypto.ts";
 import { emailsToAccountContacts } from "./utils/emailsToAccountContacts.ts";
 import { jws, jwsFetch } from "./utils/jws.ts";
 
@@ -139,7 +143,7 @@ export class AcmeClient {
 
     this.#nonceQueue.push(
       response.headers.get(REPLAY_NONCE_HEADER_KEY) ??
-      await this.#fetchNonce(),
+        await this.#fetchNonce(),
     );
 
     if (!response.ok) {
@@ -200,7 +204,7 @@ export class AcmeClient {
       );
     }
 
-    const keyPair = await generateKeyPair();
+    const keyPair = await generateKeyPair(keyPairAlgorithm);
     const jwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
 
     const externalAccountBindingJws = await (async () => {

--- a/src/AcmeClient.ts
+++ b/src/AcmeClient.ts
@@ -184,7 +184,7 @@ export class AcmeClient {
    *
    * `keyPairAlgorithm` selects the algorithm for the generated account key. It
    * is also used for every certificate key this account mints and for key
-   * rollover. Defaults to `"ec"` (ECDSA P-256).
+   * rollover. Defaults to `"ec-p256"` (ECDSA P-256).
    *
    * @see https://datatracker.ietf.org/doc/html/rfc8555#section-7.3
    * @see https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4
@@ -276,7 +276,7 @@ export class AcmeClient {
    * whose JWS algorithm is always derived from the key itself. When omitted,
    * it is derived from `keyPair` too, so an RSA account keeps minting RSA
    * certificate keys. If `keyPair` falls outside the supported set (e.g. an
-   * imported RSA-3072 key), generated keys fall back to `"ec"`.
+   * imported RSA-3072 key), generated keys fall back to `"ec-p256"`.
    *
    * @see https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.1
    */

--- a/src/AcmeClient.ts
+++ b/src/AcmeClient.ts
@@ -8,6 +8,7 @@ import {
   BadNonceError,
 } from "./errors.ts";
 import {
+  deriveKeyPairAlgorithm,
   generateKeyPair,
   importHmacKey,
   type KeyPairAlgorithm,
@@ -181,6 +182,10 @@ export class AcmeClient {
    * If the CA's directory advertises `meta.externalAccountRequired`, omitting it
    * throws before any request is made.
    *
+   * `keyPairAlgorithm` selects the algorithm for the generated account key. It
+   * is also used for every certificate key this account mints and for key
+   * rollover. Defaults to `"ec"` (ECDSA P-256).
+   *
    * @see https://datatracker.ietf.org/doc/html/rfc8555#section-7.3
    * @see https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4
    */
@@ -266,11 +271,18 @@ export class AcmeClient {
   /**
    * Login with an existing account with a keyPair
    *
+   * `keyPairAlgorithm` selects the algorithm for keys generated later on this
+   * account (certificate keys, key rollover) — it does not affect `keyPair`,
+   * whose JWS algorithm is always derived from the key itself. When omitted,
+   * it is derived from `keyPair` too, so an RSA account keeps minting RSA
+   * certificate keys. If `keyPair` falls outside the supported set (e.g. an
+   * imported RSA-3072 key), generated keys fall back to `"ec"`.
+   *
    * @see https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.1
    */
   async login({
     keyPair,
-    keyPairAlgorithm,
+    keyPairAlgorithm = deriveKeyPairAlgorithm(keyPair.privateKey),
   }: {
     keyPair: CryptoKeyPair;
     keyPairAlgorithm?: KeyPairAlgorithm;

--- a/src/AcmeOrder.ts
+++ b/src/AcmeOrder.ts
@@ -278,13 +278,14 @@ Expected order status: ${pollUntil}`);
    */
   async finalize(): Promise<CryptoKeyPair> {
     const [certKeyPair, orderResponse] = await Promise.all([
-      generateKeyPair(),
+      generateKeyPair(this.account.keyPairAlgorithm),
       this.fetch(),
     ]);
     const csr = encodeBase64Url(
       await generateCSR({
         domains: this.domains,
         keyPair: certKeyPair,
+        keyPairAlgorithm: this.account.keyPairAlgorithm,
       }),
     );
 

--- a/src/AcmeOrder.ts
+++ b/src/AcmeOrder.ts
@@ -285,7 +285,6 @@ Expected order status: ${pollUntil}`);
       await generateCSR({
         domains: this.domains,
         keyPair: certKeyPair,
-        keyPairAlgorithm: this.account.keyPairAlgorithm,
       }),
     );
 

--- a/src/Asn1/Asn1.ts
+++ b/src/Asn1/Asn1.ts
@@ -4,6 +4,7 @@ export const ASN1_TAGS = {
   INTEGER: 0x02,
   BITSTRING: 0x03,
   OCTET_STRING: 0x04,
+  NULL: 0x05,
   OID: 0x06,
   UTF8_STRING: 0x0C,
   SEQUENCE: 0x30,

--- a/src/Asn1/Asn1Encoder.ts
+++ b/src/Asn1/Asn1Encoder.ts
@@ -49,6 +49,10 @@ export const Asn1Encoder = {
     return Asn1Encoder.custom(ASN1_TAGS.BITSTRING, data);
   },
 
+  // ASN.1 NULL: a 0x05 tag with zero-length content.
+  null: (): Uint8Array<ArrayBuffer> =>
+    Asn1Encoder.custom(ASN1_TAGS.NULL, new Uint8Array(0)),
+
   uintBytes: (bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> => {
     if (bytes[0] === undefined) {
       throw new Error(

--- a/src/Asn1/Asn1Encoder.ts
+++ b/src/Asn1/Asn1Encoder.ts
@@ -65,7 +65,7 @@ export const Asn1Encoder = {
     // ECDSA r/s halves), which strict parsers would otherwise reject.
     const firstNonZeroIndex = bytes.findIndex((byte) => byte !== 0);
     const minimalBytes = firstNonZeroIndex === -1
-      ? bytes.slice(-1) // all zeros: a single 0x00 is the minimal encoding
+      ? Uint8Array.from([0]) // all zeros: a single 0x00 is the minimal encoding
       : bytes.slice(firstNonZeroIndex);
 
     // Add leading zero byte if the most significant bit is 1 so it's not mistaken as negative number!

--- a/src/Asn1/Asn1Encoder.ts
+++ b/src/Asn1/Asn1Encoder.ts
@@ -60,11 +60,23 @@ export const Asn1Encoder = {
       );
     }
 
-    // Add leading zero byte if the most significant bit is 1 so it's not mistaken as negative number!
-    if (bytes[0] & 0b1000_0000) {
-      bytes = concatUint8Arrays([0x00], bytes);
+    // DER requires INTEGERs to be minimally encoded: strip leading zero
+    // octets, keeping one when the value itself is zero. Callers pass
+    // fixed-width values (e.g. WebCrypto's zero-padded ECDSA r/s halves),
+    // which strict parsers would otherwise reject.
+    let start = 0;
+    while (start < bytes.byteLength - 1 && bytes[start] === 0) {
+      start++;
     }
-    return Asn1Encoder.custom(ASN1_TAGS.INTEGER, bytes);
+    const minimalBytes = bytes.slice(start);
+
+    // Add leading zero byte if the most significant bit is 1 so it's not mistaken as negative number!
+    return Asn1Encoder.custom(
+      ASN1_TAGS.INTEGER,
+      (minimalBytes[0] ?? 0) & 0b1000_0000
+        ? concatUint8Arrays([0x00], minimalBytes)
+        : minimalBytes,
+    );
   },
 
   uint: (n: number) => {

--- a/src/Asn1/Asn1Encoder.ts
+++ b/src/Asn1/Asn1Encoder.ts
@@ -61,14 +61,12 @@ export const Asn1Encoder = {
     }
 
     // DER requires INTEGERs to be minimally encoded: strip leading zero
-    // octets, keeping one when the value itself is zero. Callers pass
-    // fixed-width values (e.g. WebCrypto's zero-padded ECDSA r/s halves),
-    // which strict parsers would otherwise reject.
-    let start = 0;
-    while (start < bytes.byteLength - 1 && bytes[start] === 0) {
-      start++;
-    }
-    const minimalBytes = bytes.slice(start);
+    // octets. Callers pass fixed-width values (e.g. WebCrypto's zero-padded
+    // ECDSA r/s halves), which strict parsers would otherwise reject.
+    const firstNonZeroIndex = bytes.findIndex((byte) => byte !== 0);
+    const minimalBytes = firstNonZeroIndex === -1
+      ? bytes.slice(-1) // all zeros: a single 0x00 is the minimal encoding
+      : bytes.slice(firstNonZeroIndex);
 
     // Add leading zero byte if the most significant bit is 1 so it's not mistaken as negative number!
     return Asn1Encoder.custom(

--- a/src/Asn1/asn1.test.ts
+++ b/src/Asn1/asn1.test.ts
@@ -58,3 +58,15 @@ it("should decode generalized time correctly", () => {
 it("should encode ASN.1 NULL as a 0x05 tag with empty content", () => {
   expect([...Asn1Encoder.null()]).toEqual([0x05, 0x00]);
 });
+
+it("should encode INTEGERs minimally per DER", () => {
+  // Leading zero octets are stripped...
+  expect([...Asn1Encoder.uintBytes(Uint8Array.from([0x00, 0x01]))])
+    .toEqual([0x02, 0x01, 0x01]);
+  // ...but one is re-added when the most significant bit is set...
+  expect([...Asn1Encoder.uintBytes(Uint8Array.from([0x00, 0x8F]))])
+    .toEqual([0x02, 0x02, 0x00, 0x8F]);
+  // ...and a single 0x00 remains when the value is zero.
+  expect([...Asn1Encoder.uintBytes(Uint8Array.from([0x00, 0x00, 0x00]))])
+    .toEqual([0x02, 0x01, 0x00]);
+});

--- a/src/Asn1/asn1.test.ts
+++ b/src/Asn1/asn1.test.ts
@@ -54,3 +54,7 @@ it("should decode generalized time correctly", () => {
     ).toISOString(),
   ).toEqual("2195-05-05T05:55:55.000Z");
 });
+
+it("should encode ASN.1 NULL as a 0x05 tag with empty content", () => {
+  expect([...Asn1Encoder.null()]).toEqual([0x05, 0x00]);
+});

--- a/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
+++ b/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
@@ -1,21 +1,24 @@
-import { getAlgorithmProperties, type KeyPairAlgorithm } from "../utils/crypto.ts";
+import {
+  getAlgorithmProperties,
+  type KeyPairAlgorithm,
+} from "../utils/crypto.ts";
 import { extractFirstPemObject } from "../utils/pem.ts";
 
-async function derivePublicKey(
-  privateKey: CryptoKey,
-  keyPairAlgorithm: KeyPairAlgorithm = "ec",
-): Promise<CryptoKey> {
-  // d contains the private info of the key
-  const { d: _discardedPrivateInfo, ...jwkPublic } = {
-    ...await crypto.subtle.exportKey("jwk", privateKey),
-    key_ops: ["verify"],
-  };
+async function derivePublicKey(privateKey: CryptoKey): Promise<CryptoKey> {
+  const jwk = await crypto.subtle.exportKey("jwk", privateKey);
 
-  // Import the modified JWK as a public key
+  // A public JWK must not carry private material. EC private keys expose `d`;
+  // RSA private keys additionally expose the CRT values p, q, dp, dq and qi.
+  for (const field of ["d", "p", "q", "dp", "dq", "qi"] as const) {
+    delete jwk[field];
+  }
+
+  // Reuse the private key's own algorithm so the public key always matches it,
+  // regardless of which KeyPairAlgorithm was requested.
   return crypto.subtle.importKey(
     "jwk",
-    jwkPublic,
-    getAlgorithmProperties(keyPairAlgorithm),
+    { ...jwk, key_ops: ["verify"] },
+    privateKey.algorithm,
     true,
     ["verify"],
   );
@@ -38,6 +41,6 @@ export async function importKeyPairFromPemPrivateKey(
 
   return {
     privateKey,
-    publicKey: await derivePublicKey(privateKey, keyPairAlgorithm),
+    publicKey: await derivePublicKey(privateKey),
   };
 }

--- a/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
+++ b/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
@@ -1,5 +1,6 @@
 import { decodeSequence } from "../Asn1/Asn1DecodeHelpers.ts";
 import { Asn1Encoder } from "../Asn1/Asn1Encoder.ts";
+import { ALGORITHM_NAME } from "../utils/crypto.ts";
 import { omit } from "../utils/object.ts";
 import { extractFirstPemObject } from "../utils/pem.ts";
 
@@ -50,7 +51,7 @@ function getImportParameters(
   if (isEqualBytes(OID_DER.RSA_ENCRYPTION, algorithmDer)) {
     // The hash is not part of the key; SHA-256 matches the `RS256` JWS alg
     // and `sha256WithRSAEncryption` CSR signature this client produces.
-    return { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" };
+    return { name: ALGORITHM_NAME.rsa, hash: "SHA-256" };
   }
 
   if (isEqualBytes(OID_DER.ID_EC_PUBLIC_KEY, algorithmDer)) {
@@ -59,7 +60,7 @@ function getImportParameters(
         "Unsupported EC curve in PEM private key. Only P-256 (prime256v1) is supported.",
       );
     }
-    return { name: "ECDSA", namedCurve: "P-256" };
+    return { name: ALGORITHM_NAME.ec, namedCurve: "P-256" };
   }
 
   throw new Error(

--- a/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
+++ b/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
@@ -2,22 +2,27 @@ import {
   getAlgorithmProperties,
   type KeyPairAlgorithm,
 } from "../utils/crypto.ts";
+import { omit } from "../utils/object.ts";
 import { extractFirstPemObject } from "../utils/pem.ts";
+
+// JWK members that carry private key material. EC private keys expose `d`; RSA
+// private keys additionally expose the CRT values p, q, dp, dq and qi.
+const PRIVATE_JWK_MEMBERS = ["d", "p", "q", "dp", "dq", "qi"] as const;
 
 async function derivePublicKey(privateKey: CryptoKey): Promise<CryptoKey> {
   const jwk = await crypto.subtle.exportKey("jwk", privateKey);
 
-  // A public JWK must not carry private material. EC private keys expose `d`;
-  // RSA private keys additionally expose the CRT values p, q, dp, dq and qi.
-  for (const field of ["d", "p", "q", "dp", "dq", "qi"] as const) {
-    delete jwk[field];
-  }
-
-  // Reuse the private key's own algorithm so the public key always matches it,
-  // regardless of which KeyPairAlgorithm was requested.
   return crypto.subtle.importKey(
     "jwk",
-    { ...jwk, key_ops: ["verify"] },
+    {
+      ...omit(jwk, PRIVATE_JWK_MEMBERS),
+      // The exported JWK inherits the private key's `key_ops` (`["sign"]`).
+      // WebCrypto rejects a JWK whose `key_ops` is inconsistent with the
+      // requested usages (RFC 7517 §4.3), so set it to the public op.
+      key_ops: ["verify"],
+    },
+    // Reuse the private key's own algorithm so the public key always matches
+    // it, regardless of which KeyPairAlgorithm was requested.
     privateKey.algorithm,
     true,
     ["verify"],

--- a/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
+++ b/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
@@ -1,8 +1,9 @@
 import { decodeSequence } from "../Asn1/Asn1DecodeHelpers.ts";
 import { Asn1Encoder } from "../Asn1/Asn1Encoder.ts";
-import { ALGORITHM_NAME } from "../utils/crypto.ts";
+import { WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY } from "../utils/crypto.ts";
 import { omit } from "../utils/object.ts";
 import { extractFirstPemObject } from "../utils/pem.ts";
+import { isEqualUint8Arrays } from "../utils/Uint8ArrayHelpers.ts";
 
 // JWK members that carry private key material. EC private keys expose `d`;
 // RSA private keys additionally expose the CRT values p, q, dp, dq, qi and —
@@ -16,14 +17,6 @@ const OID_DER = {
   ID_EC_PUBLIC_KEY: Asn1Encoder.oid("1.2.840.10045.2.1"),
   PRIME256V1: Asn1Encoder.oid("1.2.840.10045.3.1.7"),
 } as const;
-
-const isEqualBytes = (
-  a: Uint8Array<ArrayBuffer>,
-  b: Uint8Array<ArrayBuffer> | undefined,
-): boolean =>
-  b !== undefined &&
-  a.byteLength === b.byteLength &&
-  a.every((byte, i) => byte === b[i]);
 
 /**
  * Read the WebCrypto import parameters off the PKCS#8 blob itself, so callers
@@ -48,19 +41,25 @@ function getImportParameters(
     throw new Error("Malformed PKCS#8 private key: empty AlgorithmIdentifier.");
   }
 
-  if (isEqualBytes(OID_DER.RSA_ENCRYPTION, algorithmDer)) {
+  if (isEqualUint8Arrays(algorithmDer, OID_DER.RSA_ENCRYPTION)) {
     // The hash is not part of the key; SHA-256 matches the `RS256` JWS alg
     // and `sha256WithRSAEncryption` CSR signature this client produces.
-    return { name: ALGORITHM_NAME.rsa, hash: "SHA-256" };
+    return { name: WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY.rsa, hash: "SHA-256" };
   }
 
-  if (isEqualBytes(OID_DER.ID_EC_PUBLIC_KEY, algorithmDer)) {
-    if (!isEqualBytes(OID_DER.PRIME256V1, parametersDer)) {
+  if (isEqualUint8Arrays(algorithmDer, OID_DER.ID_EC_PUBLIC_KEY)) {
+    if (
+      parametersDer === undefined ||
+      !isEqualUint8Arrays(parametersDer, OID_DER.PRIME256V1)
+    ) {
       throw new Error(
         "Unsupported EC curve in PEM private key. Only P-256 (prime256v1) is supported.",
       );
     }
-    return { name: ALGORITHM_NAME.ec, namedCurve: "P-256" };
+    return {
+      name: WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY.ec,
+      namedCurve: "P-256",
+    };
   }
 
   throw new Error(

--- a/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
+++ b/src/CryptoKeyUtils/importKeyPairFromPemPrivateKey.ts
@@ -1,13 +1,71 @@
-import {
-  getAlgorithmProperties,
-  type KeyPairAlgorithm,
-} from "../utils/crypto.ts";
+import { decodeSequence } from "../Asn1/Asn1DecodeHelpers.ts";
+import { Asn1Encoder } from "../Asn1/Asn1Encoder.ts";
 import { omit } from "../utils/object.ts";
 import { extractFirstPemObject } from "../utils/pem.ts";
 
-// JWK members that carry private key material. EC private keys expose `d`; RSA
-// private keys additionally expose the CRT values p, q, dp, dq and qi.
-const PRIVATE_JWK_MEMBERS = ["d", "p", "q", "dp", "dq", "qi"] as const;
+// JWK members that carry private key material. EC private keys expose `d`;
+// RSA private keys additionally expose the CRT values p, q, dp, dq, qi and —
+// for multi-prime keys — oth (RFC 7518 §6.3.2).
+const PRIVATE_JWK_MEMBERS = ["d", "p", "q", "dp", "dq", "qi", "oth"] as const;
+
+// The DER-encoded AlgorithmIdentifier OIDs a PKCS#8 blob can declare
+// (RFC 3279): rsaEncryption, id-ecPublicKey and the P-256 curve.
+const OID_DER = {
+  RSA_ENCRYPTION: Asn1Encoder.oid("1.2.840.113549.1.1.1"),
+  ID_EC_PUBLIC_KEY: Asn1Encoder.oid("1.2.840.10045.2.1"),
+  PRIME256V1: Asn1Encoder.oid("1.2.840.10045.3.1.7"),
+} as const;
+
+const isEqualBytes = (
+  a: Uint8Array<ArrayBuffer>,
+  b: Uint8Array<ArrayBuffer> | undefined,
+): boolean =>
+  b !== undefined &&
+  a.byteLength === b.byteLength &&
+  a.every((byte, i) => byte === b[i]);
+
+/**
+ * Read the WebCrypto import parameters off the PKCS#8 blob itself, so callers
+ * never have to say what kind of key their PEM contains.
+ *
+ * PKCS#8 (RFC 5208 §5) is `SEQUENCE { version, privateKeyAlgorithm
+ * AlgorithmIdentifier, privateKey, ... }`, and the AlgorithmIdentifier is
+ * `SEQUENCE { algorithm OID, parameters }` — for EC keys, `parameters` is the
+ * named-curve OID.
+ */
+function getImportParameters(
+  pkcs8Der: Uint8Array<ArrayBuffer>,
+): EcKeyImportParams | RsaHashedImportParams {
+  const [, algorithmIdentifierDer] = decodeSequence(pkcs8Der);
+  if (algorithmIdentifierDer === undefined) {
+    throw new Error(
+      "Malformed PKCS#8 private key: missing privateKeyAlgorithm.",
+    );
+  }
+  const [algorithmDer, parametersDer] = decodeSequence(algorithmIdentifierDer);
+  if (algorithmDer === undefined) {
+    throw new Error("Malformed PKCS#8 private key: empty AlgorithmIdentifier.");
+  }
+
+  if (isEqualBytes(OID_DER.RSA_ENCRYPTION, algorithmDer)) {
+    // The hash is not part of the key; SHA-256 matches the `RS256` JWS alg
+    // and `sha256WithRSAEncryption` CSR signature this client produces.
+    return { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" };
+  }
+
+  if (isEqualBytes(OID_DER.ID_EC_PUBLIC_KEY, algorithmDer)) {
+    if (!isEqualBytes(OID_DER.PRIME256V1, parametersDer)) {
+      throw new Error(
+        "Unsupported EC curve in PEM private key. Only P-256 (prime256v1) is supported.",
+      );
+    }
+    return { name: "ECDSA", namedCurve: "P-256" };
+  }
+
+  throw new Error(
+    "Unsupported algorithm in PEM private key. Expected an EC (P-256) or RSA key.",
+  );
+}
 
 async function derivePublicKey(privateKey: CryptoKey): Promise<CryptoKey> {
   const jwk = await crypto.subtle.exportKey("jwk", privateKey);
@@ -22,7 +80,7 @@ async function derivePublicKey(privateKey: CryptoKey): Promise<CryptoKey> {
       key_ops: ["verify"],
     },
     // Reuse the private key's own algorithm so the public key always matches
-    // it, regardless of which KeyPairAlgorithm was requested.
+    // it, regardless of what kind of key the PEM contained.
     privateKey.algorithm,
     true,
     ["verify"],
@@ -30,16 +88,19 @@ async function derivePublicKey(privateKey: CryptoKey): Promise<CryptoKey> {
 }
 
 /**
- * Import the private key in PEM format, derive its public key and return the `Promise<CryptoKeyPair>`.
+ * Import the private key in PEM (PKCS#8) format, derive its public key and
+ * return the `Promise<CryptoKeyPair>`. The key's algorithm (EC P-256 or RSA)
+ * is detected from the PEM itself.
  */
 export async function importKeyPairFromPemPrivateKey(
   pemPrivateKey: string,
-  keyPairAlgorithm: KeyPairAlgorithm = "ec",
 ): Promise<CryptoKeyPair> {
+  const pkcs8Der = extractFirstPemObject(pemPrivateKey);
+
   const privateKey = await crypto.subtle.importKey(
     "pkcs8",
-    extractFirstPemObject(pemPrivateKey),
-    getAlgorithmProperties(keyPairAlgorithm),
+    pkcs8Der,
+    getImportParameters(pkcs8Der),
     true,
     ["sign"],
   );

--- a/src/CryptoKeyUtils/mod.test.ts
+++ b/src/CryptoKeyUtils/mod.test.ts
@@ -66,9 +66,9 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMp7rnAfFJngRhXaE26+wQo9YM6hZ
     const keyPair = await generateKeyPair("rsa-2048");
     const pemKeyPair = await CryptoKeyUtils.exportKeyPairToPem(keyPair);
 
+    // No algorithm is passed: it must be detected from the PKCS#8 header.
     const imported = await CryptoKeyUtils.importKeyPairFromPemPrivateKey(
       pemKeyPair.privateKey,
-      "rsa-2048",
     );
 
     expect(imported.privateKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");
@@ -80,5 +80,29 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMp7rnAfFJngRhXaE26+wQo9YM6hZ
     expect(await CryptoKeyUtils.exportKeyPairToPem(imported)).toEqual(
       pemKeyPair,
     );
+  });
+
+  it("should reject an EC key on an unsupported curve", async () => {
+    const p384KeyPair = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-384" },
+      true,
+      ["sign", "verify"],
+    );
+    const pemKeyPair = await CryptoKeyUtils.exportKeyPairToPem(p384KeyPair);
+
+    await expect(
+      CryptoKeyUtils.importKeyPairFromPemPrivateKey(pemKeyPair.privateKey),
+    ).rejects.toThrow("Only P-256");
+  });
+
+  it("should reject a non-EC/RSA key", async () => {
+    // A throwaway Ed25519 key: `openssl genpkey -algorithm ed25519`.
+    const ed25519PemPrivateKey = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIOwlEYbGC38eaOGUtZ7xjjaeKtZ/65qalW+T2F+DAepp
+-----END PRIVATE KEY-----`;
+
+    await expect(
+      CryptoKeyUtils.importKeyPairFromPemPrivateKey(ed25519PemPrivateKey),
+    ).rejects.toThrow("Unsupported algorithm");
   });
 });

--- a/src/CryptoKeyUtils/mod.test.ts
+++ b/src/CryptoKeyUtils/mod.test.ts
@@ -63,12 +63,12 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMp7rnAfFJngRhXaE26+wQo9YM6hZ
   });
 
   it("should export and import an RSA key pair", async () => {
-    const keyPair = await generateKeyPair("rsa");
+    const keyPair = await generateKeyPair("rsa-2048");
     const pemKeyPair = await CryptoKeyUtils.exportKeyPairToPem(keyPair);
 
     const imported = await CryptoKeyUtils.importKeyPairFromPemPrivateKey(
       pemKeyPair.privateKey,
-      "rsa",
+      "rsa-2048",
     );
 
     expect(imported.privateKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");

--- a/src/CryptoKeyUtils/mod.test.ts
+++ b/src/CryptoKeyUtils/mod.test.ts
@@ -61,4 +61,24 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMp7rnAfFJngRhXaE26+wQo9YM6hZ
       pemKeyPair,
     );
   });
+
+  it("should export and import an RSA key pair", async () => {
+    const keyPair = await generateKeyPair("rsa");
+    const pemKeyPair = await CryptoKeyUtils.exportKeyPairToPem(keyPair);
+
+    const imported = await CryptoKeyUtils.importKeyPairFromPemPrivateKey(
+      pemKeyPair.privateKey,
+      "rsa",
+    );
+
+    expect(imported.privateKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");
+    expect(imported.publicKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");
+
+    // Re-exporting must yield the identical PEM, which only holds if the
+    // public key was derived correctly from the RSA private key (i.e. all
+    // private JWK members were stripped, not just `d`).
+    expect(await CryptoKeyUtils.exportKeyPairToPem(imported)).toEqual(
+      pemKeyPair,
+    );
+  });
 });

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -13,6 +13,8 @@ export * from "./AcmeChallenge.ts";
 export * from "./AcmeClient.ts";
 export * from "./AcmeOrder.ts";
 
+export type { KeyPairAlgorithm } from "./utils/crypto.ts";
+
 export * from "./ACME_DIRECTORY_URLS.ts";
 
 export * as AcmeWorkflows from "./AcmeWorkflows.ts";

--- a/src/utils/Uint8ArrayHelpers.test.ts
+++ b/src/utils/Uint8ArrayHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "../../test_deps.ts";
-import { uint8ArrayToNumber } from "./Uint8ArrayHelpers.ts";
+import { isEqualUint8Arrays, uint8ArrayToNumber } from "./Uint8ArrayHelpers.ts";
 
 describe("uint8ArrayToNumber", () => {
   it("should decode an uint8array into a number", () => {
@@ -10,5 +10,32 @@ describe("uint8ArrayToNumber", () => {
     expect(
       uint8ArrayToNumber(Uint8Array.from([0x1, 0xFF])),
     ).toBe(0x1FF);
+  });
+});
+
+describe("isEqualUint8Arrays", () => {
+  it("should return true for arrays with the same content", () => {
+    expect(
+      isEqualUint8Arrays(
+        Uint8Array.from([1, 2, 3]),
+        Uint8Array.from([1, 2, 3]),
+      ),
+    ).toBe(true);
+    expect(isEqualUint8Arrays(new Uint8Array(0), new Uint8Array(0))).toBe(true);
+  });
+
+  it("should return false when the content differs", () => {
+    expect(
+      isEqualUint8Arrays(
+        Uint8Array.from([1, 2, 3]),
+        Uint8Array.from([1, 2, 4]),
+      ),
+    ).toBe(false);
+  });
+
+  it("should return false when the lengths differ", () => {
+    expect(
+      isEqualUint8Arrays(Uint8Array.from([1, 2, 3]), Uint8Array.from([1, 2])),
+    ).toBe(false);
   });
 });

--- a/src/utils/Uint8ArrayHelpers.ts
+++ b/src/utils/Uint8ArrayHelpers.ts
@@ -32,6 +32,12 @@ export const unsignedIntegerToUint8Array = (
   return Uint8Array.from(bytes);
 };
 
+export const isEqualUint8Arrays = (
+  a: Uint8Array<ArrayBuffer>,
+  b: Uint8Array<ArrayBuffer>,
+): boolean =>
+  a.byteLength === b.byteLength && a.every((byte, i) => byte === b[i]);
+
 export const concatUint8Arrays = (
   ...xss: readonly ArrayLike<number>[]
 ): Uint8Array<ArrayBuffer> => {

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "../../test_deps.ts";
+import {
+  generateKeyPair,
+  getAlgorithmProperties,
+  getKeyAlgorithmFamily,
+  type KeyPairAlgorithm,
+} from "./crypto.ts";
+
+describe("getAlgorithmProperties", () => {
+  it("should map ec to ECDSA P-256", () => {
+    expect(getAlgorithmProperties("ec")).toEqual({
+      name: "ECDSA",
+      namedCurve: "P-256",
+    });
+  });
+
+  it("should map rsa-2048 / rsa-4096 to RSASSA-PKCS1-v1_5 with F4", () => {
+    for (
+      const [algorithm, modulusLength] of [
+        ["rsa-2048", 2048],
+        ["rsa-4096", 4096],
+      ] as const
+    ) {
+      const props = getAlgorithmProperties(algorithm);
+      expect(props.name).toBe("RSASSA-PKCS1-v1_5");
+      expect((props as RsaHashedKeyGenParams).modulusLength).toBe(
+        modulusLength,
+      );
+      // F4 = 65537, big-endian.
+      expect([...(props as RsaHashedKeyGenParams).publicExponent]).toEqual([
+        0x01,
+        0x00,
+        0x01,
+      ]);
+    }
+  });
+});
+
+describe("getKeyAlgorithmFamily", () => {
+  it("should resolve the family from the generated key", async () => {
+    for (
+      const [algorithm, family] of [
+        ["ec", "ec"],
+        ["rsa-2048", "rsa"],
+        ["rsa-4096", "rsa"],
+      ] as const satisfies [KeyPairAlgorithm, string][]
+    ) {
+      const { privateKey, publicKey } = await generateKeyPair(algorithm);
+      expect(getKeyAlgorithmFamily(privateKey)).toBe(family);
+      expect(getKeyAlgorithmFamily(publicKey)).toBe(family);
+    }
+  });
+
+  it("should throw for an unsupported algorithm", async () => {
+    const hmacKey = await crypto.subtle.importKey(
+      "raw",
+      new Uint8Array(32),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign", "verify"],
+    );
+
+    expect(() => getKeyAlgorithmFamily(hmacKey)).toThrow("Unsupported");
+  });
+});

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "../../test_deps.ts";
 import {
+  deriveKeyPairAlgorithm,
   generateKeyPair,
   getAlgorithmProperties,
   getKeyAlgorithmFamily,
@@ -61,5 +62,31 @@ describe("getKeyAlgorithmFamily", () => {
     );
 
     expect(() => getKeyAlgorithmFamily(hmacKey)).toThrow("Unsupported");
+  });
+});
+
+describe("deriveKeyPairAlgorithm", () => {
+  it("should round-trip every supported algorithm", async () => {
+    for (
+      const algorithm of [
+        "ec",
+        "rsa-2048",
+        "rsa-4096",
+      ] as const satisfies KeyPairAlgorithm[]
+    ) {
+      const { privateKey, publicKey } = await generateKeyPair(algorithm);
+      expect(deriveKeyPairAlgorithm(privateKey)).toBe(algorithm);
+      expect(deriveKeyPairAlgorithm(publicKey)).toBe(algorithm);
+    }
+  });
+
+  it("should return undefined for keys outside the supported set", async () => {
+    const p384KeyPair = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-384" },
+      false,
+      ["sign", "verify"],
+    );
+
+    expect(deriveKeyPairAlgorithm(p384KeyPair.privateKey)).toBe(undefined);
   });
 });

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -8,8 +8,8 @@ import {
 } from "./crypto.ts";
 
 describe("getAlgorithmProperties", () => {
-  it("should map ec to ECDSA P-256", () => {
-    expect(getAlgorithmProperties("ec")).toEqual({
+  it("should map ec-p256 to ECDSA P-256", () => {
+    expect(getAlgorithmProperties("ec-p256")).toEqual({
       name: "ECDSA",
       namedCurve: "P-256",
     });
@@ -41,7 +41,7 @@ describe("getKeyAlgorithmFamily", () => {
   it("should resolve the family from the generated key", async () => {
     for (
       const [algorithm, family] of [
-        ["ec", "ec"],
+        ["ec-p256", "ec"],
         ["rsa-2048", "rsa"],
         ["rsa-4096", "rsa"],
       ] as const satisfies [KeyPairAlgorithm, string][]
@@ -69,7 +69,7 @@ describe("deriveKeyPairAlgorithm", () => {
   it("should round-trip every supported algorithm", async () => {
     for (
       const algorithm of [
-        "ec",
+        "ec-p256",
         "rsa-2048",
         "rsa-4096",
       ] as const satisfies KeyPairAlgorithm[]

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "../../test_deps.ts";
 import {
   deriveKeyPairAlgorithm,
   generateKeyPair,
-  getAlgorithmProperties,
-  getKeyAlgorithmFamily,
+  getKeyGenParams,
+  getKeyPairAlgorithmFamily,
   type KeyPairAlgorithm,
 } from "./crypto.ts";
 
-describe("getAlgorithmProperties", () => {
+describe("getKeyGenParams", () => {
   it("should map ec-p256 to ECDSA P-256", () => {
-    expect(getAlgorithmProperties("ec-p256")).toEqual({
+    expect(getKeyGenParams("ec-p256")).toEqual({
       name: "ECDSA",
       namedCurve: "P-256",
     });
@@ -22,7 +22,7 @@ describe("getAlgorithmProperties", () => {
         ["rsa-4096", 4096],
       ] as const
     ) {
-      const props = getAlgorithmProperties(algorithm);
+      const props = getKeyGenParams(algorithm);
       expect(props.name).toBe("RSASSA-PKCS1-v1_5");
       expect((props as RsaHashedKeyGenParams).modulusLength).toBe(
         modulusLength,
@@ -37,7 +37,7 @@ describe("getAlgorithmProperties", () => {
   });
 });
 
-describe("getKeyAlgorithmFamily", () => {
+describe("getKeyPairAlgorithmFamily", () => {
   it("should resolve the family from the generated key", async () => {
     for (
       const [algorithm, family] of [
@@ -47,8 +47,8 @@ describe("getKeyAlgorithmFamily", () => {
       ] as const satisfies [KeyPairAlgorithm, string][]
     ) {
       const { privateKey, publicKey } = await generateKeyPair(algorithm);
-      expect(getKeyAlgorithmFamily(privateKey)).toBe(family);
-      expect(getKeyAlgorithmFamily(publicKey)).toBe(family);
+      expect(getKeyPairAlgorithmFamily(privateKey)).toBe(family);
+      expect(getKeyPairAlgorithmFamily(publicKey)).toBe(family);
     }
   });
 
@@ -61,7 +61,7 @@ describe("getKeyAlgorithmFamily", () => {
       ["sign", "verify"],
     );
 
-    expect(() => getKeyAlgorithmFamily(hmacKey)).toThrow("Unsupported");
+    expect(() => getKeyPairAlgorithmFamily(hmacKey)).toThrow("Unsupported");
   });
 });
 

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,8 +1,34 @@
 import { decodeBase64Url } from "./base64.ts";
 
-export async function generateKeyPair(): Promise<CryptoKeyPair> {
+export type KeyPairAlgorithm = "ec" | "rsa" | "rsa-4096";
+
+export function getAlgorithmProperties(keyPairAlgorithm: KeyPairAlgorithm) {
+  switch (keyPairAlgorithm){
+    case "ec":
+      return {
+        name: "ECDSA",
+        namedCurve: "P-256",
+      };
+    case "rsa":
+      return {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+        hash: { name: "SHA-256" },
+      };
+    case "rsa-4096":
+      return {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 4096,
+        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+        hash: { name: "SHA-256" },
+      };
+  }
+}
+
+export async function generateKeyPair(keyPairAlgorithm: KeyPairAlgorithm = "ec"): Promise<CryptoKeyPair> {
   return await crypto.subtle.generateKey(
-    { name: "ECDSA", namedCurve: "P-256" },
+    getAlgorithmProperties(keyPairAlgorithm),
     true,
     ["sign", "verify"],
   );

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -73,6 +73,31 @@ export function getAlgorithmProperties(
   return ALGORITHM_PROPERTIES[keyPairAlgorithm];
 }
 
+/**
+ * Derive the {@link KeyPairAlgorithm} that would generate a key like this one,
+ * or `undefined` when the key falls outside the supported set (e.g. an
+ * imported RSA-3072 or P-384 key). Such keys can still sign JWS requests —
+ * only key generation (certificate keys, key rollover) needs a
+ * {@link KeyPairAlgorithm}.
+ */
+export function deriveKeyPairAlgorithm(
+  key: CryptoKey,
+): KeyPairAlgorithm | undefined {
+  const { name, namedCurve, modulusLength } = key.algorithm as
+    & KeyAlgorithm
+    & Partial<EcKeyAlgorithm & RsaHashedKeyAlgorithm>;
+
+  return (Object.keys(ALGORITHM_PROPERTIES) as KeyPairAlgorithm[]).find(
+    (keyPairAlgorithm) => {
+      const properties = ALGORITHM_PROPERTIES[keyPairAlgorithm];
+      return properties.name === name &&
+        ("namedCurve" in properties
+          ? properties.namedCurve === namedCurve
+          : properties.modulusLength === modulusLength);
+    },
+  );
+}
+
 export async function generateKeyPair(
   keyPairAlgorithm: KeyPairAlgorithm = "ec",
 ): Promise<CryptoKeyPair> {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -5,40 +5,67 @@ import { decodeBase64Url } from "./base64.ts";
  * mints.
  *
  * - `ec`: ECDSA on the NIST P-256 curve (signed as `ES256`). The default.
- * - `rsa`: RSASSA-PKCS1-v1_5 with a 2048-bit modulus (signed as `RS256`).
- * - `rsa-4096`: as `rsa`, but with a 4096-bit modulus.
+ * - `rsa-2048`: RSASSA-PKCS1-v1_5 with a 2048-bit modulus (signed as `RS256`).
+ * - `rsa-4096`: as `rsa-2048`, but with a 4096-bit modulus.
  */
-export type KeyPairAlgorithm = "ec" | "rsa" | "rsa-4096";
+export type KeyPairAlgorithm = "ec" | "rsa-2048" | "rsa-4096";
 
 /**
- * The signature-scheme family of a key. `rsa` and `rsa-4096` sign and encode
+ * The signature-scheme family of a key. The RSA variants sign and encode
  * identically (only the modulus size differs), so they collapse into one
  * family for the purposes of JWS and CSR encoding.
  */
 export type KeyAlgorithmFamily = "ec" | "rsa";
 
-export function getAlgorithmProperties(keyPairAlgorithm: KeyPairAlgorithm) {
-  switch (keyPairAlgorithm) {
-    case "ec":
-      return {
-        name: "ECDSA",
-        namedCurve: "P-256",
-      };
-    case "rsa":
-      return {
-        name: "RSASSA-PKCS1-v1_5",
-        modulusLength: 2048,
-        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-        hash: { name: "SHA-256" },
-      };
-    case "rsa-4096":
-      return {
-        name: "RSASSA-PKCS1-v1_5",
-        modulusLength: 4096,
-        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-        hash: { name: "SHA-256" },
-      };
-  }
+/**
+ * The RSA public exponent F4 (65537), as the big-endian byte array WebCrypto
+ * expects (`0x010001` = 65537). F4 is the standard exponent for RSA keys
+ * (NIST SP 800-56B Rev. 2 §6.2).
+ */
+const RSA_PUBLIC_EXPONENT = new Uint8Array([0x01, 0x00, 0x01]);
+
+/** The WebCrypto `algorithm.name` reported by each key family. */
+const ALGORITHM_NAME = {
+  ec: "ECDSA",
+  rsa: "RSASSA-PKCS1-v1_5",
+} as const;
+
+/**
+ * Map a {@link KeyPairAlgorithm} to the WebCrypto parameters used to generate
+ * or import it.
+ */
+const ALGORITHM_PROPERTIES: Record<
+  KeyPairAlgorithm,
+  EcKeyGenParams | RsaHashedKeyGenParams
+> = {
+  "ec": {
+    name: ALGORITHM_NAME.ec,
+    namedCurve: "P-256",
+  },
+  "rsa-2048": {
+    name: ALGORITHM_NAME.rsa,
+    modulusLength: 2048,
+    publicExponent: RSA_PUBLIC_EXPONENT,
+    hash: { name: "SHA-256" },
+  },
+  "rsa-4096": {
+    name: ALGORITHM_NAME.rsa,
+    modulusLength: 4096,
+    publicExponent: RSA_PUBLIC_EXPONENT,
+    hash: { name: "SHA-256" },
+  },
+};
+
+/** Map a key's reported WebCrypto `algorithm.name` back to its family. */
+const FAMILY_BY_ALGORITHM_NAME: Record<string, KeyAlgorithmFamily> = {
+  [ALGORITHM_NAME.ec]: "ec",
+  [ALGORITHM_NAME.rsa]: "rsa",
+};
+
+export function getAlgorithmProperties(
+  keyPairAlgorithm: KeyPairAlgorithm,
+): EcKeyGenParams | RsaHashedKeyGenParams {
+  return ALGORITHM_PROPERTIES[keyPairAlgorithm];
 }
 
 export async function generateKeyPair(
@@ -57,9 +84,19 @@ export async function generateKeyPair(
  * Reading the algorithm off the {@link CryptoKey} — rather than a separately
  * passed hint that can be omitted — guarantees the JWS `alg` and the CSR
  * signature encoding can never disagree with the actual key material.
+ *
+ * @throws if the key uses an algorithm this client does not support.
  */
 export function getKeyAlgorithmFamily(key: CryptoKey): KeyAlgorithmFamily {
-  return key.algorithm.name.startsWith("RSA") ? "rsa" : "ec";
+  const family = FAMILY_BY_ALGORITHM_NAME[key.algorithm.name];
+  if (family === undefined) {
+    throw new Error(
+      `Unsupported key algorithm "${key.algorithm.name}". Expected one of: ${
+        Object.keys(FAMILY_BY_ALGORITHM_NAME).join(", ")
+      }.`,
+    );
+  }
+  return family;
 }
 
 /**

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,43 +1,38 @@
 import { decodeBase64Url } from "./base64.ts";
 
 /**
- * The key algorithm used for an account's keys and the certificate keys it
- * mints.
- *
- * - `ec`: ECDSA on the NIST P-256 curve (signed as `ES256`). The default.
- * - `rsa-2048`: RSASSA-PKCS1-v1_5 with a 2048-bit modulus (signed as `RS256`).
- * - `rsa-4096`: as `rsa-2048`, but with a 4096-bit modulus.
- */
-export type KeyPairAlgorithm = "ec" | "rsa-2048" | "rsa-4096";
-
-/**
- * The signature-scheme family of a key. The RSA variants sign and encode
- * identically (only the modulus size differs), so they collapse into one
- * family for the purposes of JWS and CSR encoding.
- */
-export type KeyAlgorithmFamily = "ec" | "rsa";
-
-/**
  * The RSA public exponent F4 (65537), as the big-endian byte array WebCrypto
  * expects (`0x010001` = 65537). F4 is the standard exponent for RSA keys
  * (NIST SP 800-56B Rev. 2 §6.2).
  */
-const RSA_PUBLIC_EXPONENT = new Uint8Array([0x01, 0x00, 0x01]);
+const RSA_PUBLIC_EXPONENT: Uint8Array<ArrayBuffer> = new Uint8Array([
+  0x01,
+  0x00,
+  0x01,
+]);
 
-/** The WebCrypto `algorithm.name` reported by each key family. */
+/**
+ * The WebCrypto `algorithm.name` reported by each key family. Its keys are the
+ * source of truth for {@link KeyAlgorithmFamily}.
+ */
 const ALGORITHM_NAME = {
   ec: "ECDSA",
   rsa: "RSASSA-PKCS1-v1_5",
 } as const;
 
 /**
- * Map a {@link KeyPairAlgorithm} to the WebCrypto parameters used to generate
- * or import it.
+ * The signature-scheme family of a key. The RSA variants sign and encode
+ * identically (only the modulus size differs), so they collapse into one
+ * family for the purposes of JWS and CSR encoding.
  */
-const ALGORITHM_PROPERTIES: Record<
-  KeyPairAlgorithm,
-  EcKeyGenParams | RsaHashedKeyGenParams
-> = {
+export type KeyAlgorithmFamily = keyof typeof ALGORITHM_NAME;
+
+/**
+ * The WebCrypto parameters used to generate or import each supported key
+ * algorithm. Its keys are the source of truth for {@link KeyPairAlgorithm};
+ * `satisfies` validates every entry without widening the literal types away.
+ */
+const ALGORITHM_PROPERTIES = {
   "ec": {
     name: ALGORITHM_NAME.ec,
     namedCurve: "P-256",
@@ -54,7 +49,17 @@ const ALGORITHM_PROPERTIES: Record<
     publicExponent: RSA_PUBLIC_EXPONENT,
     hash: { name: "SHA-256" },
   },
-};
+} as const satisfies Record<string, EcKeyGenParams | RsaHashedKeyGenParams>;
+
+/**
+ * The key algorithm used for an account's keys and the certificate keys it
+ * mints.
+ *
+ * - `ec`: ECDSA on the NIST P-256 curve (signed as `ES256`). The default.
+ * - `rsa-2048`: RSASSA-PKCS1-v1_5 with a 2048-bit modulus (signed as `RS256`).
+ * - `rsa-4096`: as `rsa-2048`, but with a 4096-bit modulus.
+ */
+export type KeyPairAlgorithm = keyof typeof ALGORITHM_PROPERTIES;
 
 /** Map a key's reported WebCrypto `algorithm.name` back to its family. */
 const FAMILY_BY_ALGORITHM_NAME: Record<string, KeyAlgorithmFamily> = {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -15,7 +15,7 @@ const RSA_PUBLIC_EXPONENT: Uint8Array<ArrayBuffer> = new Uint8Array([
  * The WebCrypto `algorithm.name` reported by each key family. Its keys are the
  * source of truth for {@link KeyAlgorithmFamily}.
  */
-const ALGORITHM_NAME = {
+export const ALGORITHM_NAME = {
   ec: "ECDSA",
   rsa: "RSASSA-PKCS1-v1_5",
 } as const;
@@ -41,13 +41,13 @@ const ALGORITHM_PROPERTIES = {
     name: ALGORITHM_NAME.rsa,
     modulusLength: 2048,
     publicExponent: RSA_PUBLIC_EXPONENT,
-    hash: { name: "SHA-256" },
+    hash: "SHA-256",
   },
   "rsa-4096": {
     name: ALGORITHM_NAME.rsa,
     modulusLength: 4096,
     publicExponent: RSA_PUBLIC_EXPONENT,
-    hash: { name: "SHA-256" },
+    hash: "SHA-256",
   },
 } as const satisfies Record<string, EcKeyGenParams | RsaHashedKeyGenParams>;
 

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,9 +1,24 @@
 import { decodeBase64Url } from "./base64.ts";
 
+/**
+ * The key algorithm used for an account's keys and the certificate keys it
+ * mints.
+ *
+ * - `ec`: ECDSA on the NIST P-256 curve (signed as `ES256`). The default.
+ * - `rsa`: RSASSA-PKCS1-v1_5 with a 2048-bit modulus (signed as `RS256`).
+ * - `rsa-4096`: as `rsa`, but with a 4096-bit modulus.
+ */
 export type KeyPairAlgorithm = "ec" | "rsa" | "rsa-4096";
 
+/**
+ * The signature-scheme family of a key. `rsa` and `rsa-4096` sign and encode
+ * identically (only the modulus size differs), so they collapse into one
+ * family for the purposes of JWS and CSR encoding.
+ */
+export type KeyAlgorithmFamily = "ec" | "rsa";
+
 export function getAlgorithmProperties(keyPairAlgorithm: KeyPairAlgorithm) {
-  switch (keyPairAlgorithm){
+  switch (keyPairAlgorithm) {
     case "ec":
       return {
         name: "ECDSA",
@@ -26,12 +41,25 @@ export function getAlgorithmProperties(keyPairAlgorithm: KeyPairAlgorithm) {
   }
 }
 
-export async function generateKeyPair(keyPairAlgorithm: KeyPairAlgorithm = "ec"): Promise<CryptoKeyPair> {
+export async function generateKeyPair(
+  keyPairAlgorithm: KeyPairAlgorithm = "ec",
+): Promise<CryptoKeyPair> {
   return await crypto.subtle.generateKey(
     getAlgorithmProperties(keyPairAlgorithm),
     true,
     ["sign", "verify"],
   );
+}
+
+/**
+ * Resolve a key's {@link KeyAlgorithmFamily} from the key itself.
+ *
+ * Reading the algorithm off the {@link CryptoKey} — rather than a separately
+ * passed hint that can be omitted — guarantees the JWS `alg` and the CSR
+ * signature encoding can never disagree with the actual key material.
+ */
+export function getKeyAlgorithmFamily(key: CryptoKey): KeyAlgorithmFamily {
+  return key.algorithm.name.startsWith("RSA") ? "rsa" : "ec";
 }
 
 /**

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,4 +1,20 @@
 import { decodeBase64Url } from "./base64.ts";
+import type { ExclusifyUnion } from "./types.ts";
+
+/**
+ * Naming used throughout this module (and the modules that build on it):
+ *
+ * - A **key pair algorithm** ({@link KeyPairAlgorithm}, e.g. `"ec-p256"`,
+ *   `"rsa-2048"`) is the full recipe for generating a key pair: a family plus
+ *   its parameters (curve or modulus size). This is what users pick.
+ * - Its **family** ({@link KeyPairAlgorithmFamily}: `"ec"` | `"rsa"`) is the
+ *   signature scheme, which is all that JWS and CSR encoding care about.
+ * - The **WebCrypto algorithm name** (`"ECDSA"`, `"RSASSA-PKCS1-v1_5"`) is
+ *   what the runtime reports on `CryptoKey#algorithm.name`; it identifies the
+ *   family but is spelled by the WebCrypto spec, not by us.
+ *
+ * Lookup tables are named `<VALUE>_BY_<KEY>`.
+ */
 
 /**
  * The RSA public exponent F4 (65537), as the big-endian byte array WebCrypto
@@ -13,9 +29,9 @@ const RSA_PUBLIC_EXPONENT: Uint8Array<ArrayBuffer> = new Uint8Array([
 
 /**
  * The WebCrypto `algorithm.name` reported by each key family. Its keys are the
- * source of truth for {@link KeyAlgorithmFamily}.
+ * source of truth for {@link KeyPairAlgorithmFamily}.
  */
-export const ALGORITHM_NAME = {
+export const WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY = {
   ec: "ECDSA",
   rsa: "RSASSA-PKCS1-v1_5",
 } as const;
@@ -25,26 +41,27 @@ export const ALGORITHM_NAME = {
  * identically (only the modulus size differs), so they collapse into one
  * family for the purposes of JWS and CSR encoding.
  */
-export type KeyAlgorithmFamily = keyof typeof ALGORITHM_NAME;
+export type KeyPairAlgorithmFamily =
+  keyof typeof WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY;
 
 /**
- * The WebCrypto parameters used to generate or import each supported key
- * algorithm. Its keys are the source of truth for {@link KeyPairAlgorithm};
- * `satisfies` validates every entry without widening the literal types away.
+ * The WebCrypto parameters used to generate each supported key algorithm. Its
+ * keys are the source of truth for {@link KeyPairAlgorithm}; `satisfies`
+ * validates every entry without widening the literal types away.
  */
-const ALGORITHM_PROPERTIES = {
+const KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM = {
   "ec-p256": {
-    name: ALGORITHM_NAME.ec,
+    name: WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY.ec,
     namedCurve: "P-256",
   },
   "rsa-2048": {
-    name: ALGORITHM_NAME.rsa,
+    name: WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY.rsa,
     modulusLength: 2048,
     publicExponent: RSA_PUBLIC_EXPONENT,
     hash: "SHA-256",
   },
   "rsa-4096": {
-    name: ALGORITHM_NAME.rsa,
+    name: WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY.rsa,
     modulusLength: 4096,
     publicExponent: RSA_PUBLIC_EXPONENT,
     hash: "SHA-256",
@@ -59,18 +76,22 @@ const ALGORITHM_PROPERTIES = {
  * - `rsa-2048`: RSASSA-PKCS1-v1_5 with a 2048-bit modulus (signed as `RS256`).
  * - `rsa-4096`: as `rsa-2048`, but with a 4096-bit modulus.
  */
-export type KeyPairAlgorithm = keyof typeof ALGORITHM_PROPERTIES;
+export type KeyPairAlgorithm =
+  keyof typeof KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM;
 
 /** Map a key's reported WebCrypto `algorithm.name` back to its family. */
-const FAMILY_BY_ALGORITHM_NAME: Record<string, KeyAlgorithmFamily> = {
-  [ALGORITHM_NAME.ec]: "ec",
-  [ALGORITHM_NAME.rsa]: "rsa",
+const FAMILY_BY_WEB_CRYPTO_ALGORITHM_NAME: Record<
+  string,
+  KeyPairAlgorithmFamily
+> = {
+  [WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY.ec]: "ec",
+  [WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY.rsa]: "rsa",
 };
 
-export function getAlgorithmProperties(
+export function getKeyGenParams(
   keyPairAlgorithm: KeyPairAlgorithm,
 ): EcKeyGenParams | RsaHashedKeyGenParams {
-  return ALGORITHM_PROPERTIES[keyPairAlgorithm];
+  return KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM[keyPairAlgorithm];
 }
 
 /**
@@ -83,17 +104,22 @@ export function getAlgorithmProperties(
 export function deriveKeyPairAlgorithm(
   key: CryptoKey,
 ): KeyPairAlgorithm | undefined {
-  const { name, namedCurve, modulusLength } = key.algorithm as
-    & KeyAlgorithm
-    & Partial<EcKeyAlgorithm & RsaHashedKeyAlgorithm>;
+  const { name, namedCurve, modulusLength } = key.algorithm as ExclusifyUnion<
+    EcKeyAlgorithm | RsaHashedKeyAlgorithm
+  >;
 
-  return (Object.keys(ALGORITHM_PROPERTIES) as KeyPairAlgorithm[]).find(
+  return (Object.keys(
+    KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM,
+  ) as KeyPairAlgorithm[]).find(
     (keyPairAlgorithm) => {
-      const properties = ALGORITHM_PROPERTIES[keyPairAlgorithm];
-      return properties.name === name &&
-        ("namedCurve" in properties
-          ? properties.namedCurve === namedCurve
-          : properties.modulusLength === modulusLength);
+      const params: ExclusifyUnion<EcKeyGenParams | RsaHashedKeyGenParams> =
+        KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM[keyPairAlgorithm];
+      // Members a family lacks are `undefined` on both sides (see
+      // ExclusifyUnion), so the same equalities cover EC (namedCurve)
+      // and RSA (modulusLength) alike.
+      return params.name === name &&
+        params.namedCurve === namedCurve &&
+        params.modulusLength === modulusLength;
     },
   );
 }
@@ -102,14 +128,14 @@ export async function generateKeyPair(
   keyPairAlgorithm: KeyPairAlgorithm = "ec-p256",
 ): Promise<CryptoKeyPair> {
   return await crypto.subtle.generateKey(
-    getAlgorithmProperties(keyPairAlgorithm),
+    getKeyGenParams(keyPairAlgorithm),
     true,
     ["sign", "verify"],
   );
 }
 
 /**
- * Resolve a key's {@link KeyAlgorithmFamily} from the key itself.
+ * Resolve a key's {@link KeyPairAlgorithmFamily} from the key itself.
  *
  * Reading the algorithm off the {@link CryptoKey} — rather than a separately
  * passed hint that can be omitted — guarantees the JWS `alg` and the CSR
@@ -117,12 +143,14 @@ export async function generateKeyPair(
  *
  * @throws if the key uses an algorithm this client does not support.
  */
-export function getKeyAlgorithmFamily(key: CryptoKey): KeyAlgorithmFamily {
-  const family = FAMILY_BY_ALGORITHM_NAME[key.algorithm.name];
+export function getKeyPairAlgorithmFamily(
+  key: CryptoKey,
+): KeyPairAlgorithmFamily {
+  const family = FAMILY_BY_WEB_CRYPTO_ALGORITHM_NAME[key.algorithm.name];
   if (family === undefined) {
     throw new Error(
       `Unsupported key algorithm "${key.algorithm.name}". Expected one of: ${
-        Object.keys(FAMILY_BY_ALGORITHM_NAME).join(", ")
+        Object.keys(FAMILY_BY_WEB_CRYPTO_ALGORITHM_NAME).join(", ")
       }.`,
     );
   }

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -33,7 +33,7 @@ export type KeyAlgorithmFamily = keyof typeof ALGORITHM_NAME;
  * `satisfies` validates every entry without widening the literal types away.
  */
 const ALGORITHM_PROPERTIES = {
-  "ec": {
+  "ec-p256": {
     name: ALGORITHM_NAME.ec,
     namedCurve: "P-256",
   },
@@ -55,7 +55,7 @@ const ALGORITHM_PROPERTIES = {
  * The key algorithm used for an account's keys and the certificate keys it
  * mints.
  *
- * - `ec`: ECDSA on the NIST P-256 curve (signed as `ES256`). The default.
+ * - `ec-p256`: ECDSA on the NIST P-256 curve (signed as `ES256`). The default.
  * - `rsa-2048`: RSASSA-PKCS1-v1_5 with a 2048-bit modulus (signed as `RS256`).
  * - `rsa-4096`: as `rsa-2048`, but with a 4096-bit modulus.
  */
@@ -99,7 +99,7 @@ export function deriveKeyPairAlgorithm(
 }
 
 export async function generateKeyPair(
-  keyPairAlgorithm: KeyPairAlgorithm = "ec",
+  keyPairAlgorithm: KeyPairAlgorithm = "ec-p256",
 ): Promise<CryptoKeyPair> {
   return await crypto.subtle.generateKey(
     getAlgorithmProperties(keyPairAlgorithm),

--- a/src/utils/generateCSR.deno.test.ts
+++ b/src/utils/generateCSR.deno.test.ts
@@ -173,4 +173,42 @@ describe("generateCSR", () => {
       await openssl.verifyCSR(generatedCSR),
     ).toContain("verify OK");
   });
+
+  // Regression guard: a key built with the default algorithm must yield an
+  // ECDSA CSR. A previous iteration defaulted the signatureAlgorithm and
+  // signature encoding to RSA whenever no algorithm hint was threaded through,
+  // producing an invalid CSR for the (default) EC path.
+  it("should default to an ECDSA CSR", async () => {
+    const keyPair = await generateKeyPair();
+
+    const generatedCSR = formatPEM(
+      "CERTIFICATE REQUEST",
+      encodeBase64(await generateCSR({ domains: ["example.com"], keyPair })),
+    );
+
+    expect(await openssl.verifyCSR(generatedCSR)).toContain("verify OK");
+    expect(await openssl.getCSRInfo(generatedCSR)).toContain(
+      "Signature Algorithm: ecdsa-with-SHA256",
+    );
+  });
+
+  for (const keyPairAlgorithm of ["rsa", "rsa-4096"] as const) {
+    it(`should generate a valid CSR for "${keyPairAlgorithm}" keys`, async () => {
+      const domains = ["example.com", "www.example.com"];
+      const keyPair = await generateKeyPair(keyPairAlgorithm);
+
+      const generatedCSR = formatPEM(
+        "CERTIFICATE REQUEST",
+        encodeBase64(await generateCSR({ domains, keyPair })),
+      );
+
+      // OpenSSL re-verifies the CSR self-signature, which only succeeds when
+      // the signatureAlgorithm and the signature encoding match the key.
+      expect(await openssl.verifyCSR(generatedCSR)).toContain("verify OK");
+
+      const csrInfo = await openssl.getCSRInfo(generatedCSR);
+      expect(csrInfo).toContain("Public Key Algorithm: rsaEncryption");
+      expect(csrInfo).toContain("Signature Algorithm: sha256WithRSAEncryption");
+    });
+  }
 });

--- a/src/utils/generateCSR.deno.test.ts
+++ b/src/utils/generateCSR.deno.test.ts
@@ -192,7 +192,7 @@ describe("generateCSR", () => {
     );
   });
 
-  for (const keyPairAlgorithm of ["rsa", "rsa-4096"] as const) {
+  for (const keyPairAlgorithm of ["rsa-2048", "rsa-4096"] as const) {
     it(`should generate a valid CSR for "${keyPairAlgorithm}" keys`, async () => {
       const domains = ["example.com", "www.example.com"];
       const keyPair = await generateKeyPair(keyPairAlgorithm);

--- a/src/utils/generateCSR.ts
+++ b/src/utils/generateCSR.ts
@@ -6,7 +6,11 @@
 
 import { Asn1Encoder } from "../Asn1/Asn1Encoder.ts";
 import { splitAtIndex } from "./array.ts";
-import { type KeyPairAlgorithm, sign } from "./crypto.ts";
+import {
+  getKeyAlgorithmFamily,
+  type KeyAlgorithmFamily,
+  sign,
+} from "./crypto.ts";
 
 const OIDS = {
   COMMON_NAME: "2.5.4.3",
@@ -17,21 +21,57 @@ const OIDS = {
 } as const;
 
 /**
+ * Per-family encoding of the CSR `signatureAlgorithm` field and of the raw
+ * signature WebCrypto produces. The family is derived from the signing key
+ * (see {@link getKeyAlgorithmFamily}), so the CSR always matches its key.
+ *
+ * - `ec`: ECDSA-with-SHA-256 with absent parameters (RFC 5758 §3.2). WebCrypto
+ *   returns the raw `r‖s` pair, which X.509 wraps as `SEQUENCE { r, s }`
+ *   (RFC 3279 §2.2.3).
+ * - `rsa`: sha256WithRSAEncryption whose parameters MUST be explicit NULL
+ *   (RFC 4055 §5); the PKCS#1 v1.5 signature is carried verbatim.
+ */
+const CSR_SIGNATURE_STRATEGY: Record<KeyAlgorithmFamily, {
+  signatureAlgorithm: Uint8Array<ArrayBuffer>;
+  encodeSignatureValue: (
+    signature: Uint8Array<ArrayBuffer>,
+  ) => Uint8Array<ArrayBuffer>;
+}> = {
+  ec: {
+    signatureAlgorithm: Asn1Encoder.sequence(
+      Asn1Encoder.oid(OIDS.ECDSA_WITH_SHA256),
+    ),
+    encodeSignatureValue: (signature) => {
+      const [r, s] = splitAtIndex(signature, signature.byteLength / 2);
+      return Asn1Encoder.sequence(
+        Asn1Encoder.uintBytes(r),
+        Asn1Encoder.uintBytes(s),
+      );
+    },
+  },
+  rsa: {
+    signatureAlgorithm: Asn1Encoder.sequence(
+      Asn1Encoder.oid(OIDS.RSA_WITH_SHA256),
+      Asn1Encoder.null(),
+    ),
+    encodeSignatureValue: (signature) => signature,
+  },
+};
+
+/**
  * Generate a Certificate Signing Request (CSR) in DER format.
+ *
+ * The signature scheme (ECDSA or RSASSA-PKCS1-v1_5) is derived from `keyPair`
+ * itself, so the CSR always matches the key it is built from.
  *
  * @see https://datatracker.ietf.org/doc/html/rfc2986
  */
 export async function generateCSR(
-  {
-    domains,
-    keyPair,
-    keyPairAlgorithm,
-  }: {
-    domains: readonly string[];
-    keyPair: CryptoKeyPair;
-    keyPairAlgorithm?: KeyPairAlgorithm;
-  },
+  { domains, keyPair }: { domains: readonly string[]; keyPair: CryptoKeyPair },
 ): Promise<Uint8Array<ArrayBuffer>> {
+  const { signatureAlgorithm, encodeSignatureValue } =
+    CSR_SIGNATURE_STRATEGY[getKeyAlgorithmFamily(keyPair.privateKey)];
+
   const certificationRequestInfoSequence = encodeCertificationRequestInfo(
     {
       domains,
@@ -53,13 +93,12 @@ export async function generateCSR(
     // certificationRequestInfo
     certificationRequestInfoSequence,
     // signatureAlgorithm
-    Asn1Encoder.sequence(
-      Asn1Encoder.oid(keyPairAlgorithm === "ec" ? OIDS.ECDSA_WITH_SHA256 : OIDS.RSA_WITH_SHA256),
-    ),
+    signatureAlgorithm,
     // signature
-    encodeSignatureBitString(
-      await sign(keyPair.privateKey, certificationRequestInfoSequence),
-      keyPairAlgorithm,
+    Asn1Encoder.bitString(
+      encodeSignatureValue(
+        await sign(keyPair.privateKey, certificationRequestInfoSequence),
+      ),
     ),
   );
 }
@@ -141,18 +180,3 @@ const encodeSubjectAlternativeName = (() => {
     );
   };
 })();
-
-const encodeSignatureBitString = (
-  signature: Uint8Array<ArrayBuffer>,
-  keyPairAlgorithm?: KeyPairAlgorithm,
-): Uint8Array<ArrayBuffer> => {
-  if (keyPairAlgorithm === "ec") {
-    const [r, s] = splitAtIndex(signature, signature.byteLength / 2);
-
-    return Asn1Encoder.bitString(Asn1Encoder.sequence(
-      Asn1Encoder.uintBytes(r),
-      Asn1Encoder.uintBytes(s),
-    ));
-  }
-  return Asn1Encoder.bitString(signature);
-};

--- a/src/utils/generateCSR.ts
+++ b/src/utils/generateCSR.ts
@@ -7,8 +7,8 @@
 import { Asn1Encoder } from "../Asn1/Asn1Encoder.ts";
 import { splitAtIndex } from "./array.ts";
 import {
-  getKeyAlgorithmFamily,
-  type KeyAlgorithmFamily,
+  getKeyPairAlgorithmFamily,
+  type KeyPairAlgorithmFamily,
   sign,
 } from "./crypto.ts";
 
@@ -23,7 +23,7 @@ const OIDS = {
 /**
  * Per-family encoding of the CSR `signatureAlgorithm` field and of the raw
  * signature WebCrypto produces. The family is derived from the signing key
- * (see {@link getKeyAlgorithmFamily}), so the CSR always matches its key.
+ * (see {@link getKeyPairAlgorithmFamily}), so the CSR always matches its key.
  *
  * - `ec`: ECDSA-with-SHA-256 with absent parameters (RFC 5758 §3.2). WebCrypto
  *   returns the raw `r‖s` pair, which X.509 wraps as `SEQUENCE { r, s }`
@@ -31,7 +31,7 @@ const OIDS = {
  * - `rsa`: sha256WithRSAEncryption whose parameters MUST be explicit NULL
  *   (RFC 4055 §5); the PKCS#1 v1.5 signature is carried verbatim.
  */
-const CSR_SIGNATURE_STRATEGY: Record<KeyAlgorithmFamily, {
+const CSR_SIGNATURE_STRATEGY_BY_FAMILY: Record<KeyPairAlgorithmFamily, {
   signatureAlgorithm: Uint8Array<ArrayBuffer>;
   encodeSignatureValue: (
     signature: Uint8Array<ArrayBuffer>,
@@ -70,7 +70,9 @@ export async function generateCSR(
   { domains, keyPair }: { domains: readonly string[]; keyPair: CryptoKeyPair },
 ): Promise<Uint8Array<ArrayBuffer>> {
   const { signatureAlgorithm, encodeSignatureValue } =
-    CSR_SIGNATURE_STRATEGY[getKeyAlgorithmFamily(keyPair.privateKey)];
+    CSR_SIGNATURE_STRATEGY_BY_FAMILY[
+      getKeyPairAlgorithmFamily(keyPair.privateKey)
+    ];
 
   const certificationRequestInfoSequence = encodeCertificationRequestInfo(
     {

--- a/src/utils/generateCSR.ts
+++ b/src/utils/generateCSR.ts
@@ -6,15 +6,14 @@
 
 import { Asn1Encoder } from "../Asn1/Asn1Encoder.ts";
 import { splitAtIndex } from "./array.ts";
-import { sign } from "./crypto.ts";
+import { type KeyPairAlgorithm, sign } from "./crypto.ts";
 
 const OIDS = {
   COMMON_NAME: "2.5.4.3",
   SUBJECT_ALT_NAME: "2.5.29.17",
-  ID_EC_PUBLIC_KEY: "1.2.840.10045.2.1",
-  PRIME256V1: "1.2.840.10045.3.1.7",
   ECDSA_WITH_SHA256: "1.2.840.10045.4.3.2",
-  EXTENSION_REQUET: "1.2.840.113549.1.9.14",
+  RSA_WITH_SHA256: "1.2.840.113549.1.1.11",
+  EXTENSION_REQUEST: "1.2.840.113549.1.9.14",
 } as const;
 
 /**
@@ -23,13 +22,21 @@ const OIDS = {
  * @see https://datatracker.ietf.org/doc/html/rfc2986
  */
 export async function generateCSR(
-  { domains, keyPair }: { domains: readonly string[]; keyPair: CryptoKeyPair },
+  {
+    domains,
+    keyPair,
+    keyPairAlgorithm,
+  }: {
+    domains: readonly string[];
+    keyPair: CryptoKeyPair;
+    keyPairAlgorithm?: KeyPairAlgorithm;
+  },
 ): Promise<Uint8Array<ArrayBuffer>> {
   const certificationRequestInfoSequence = encodeCertificationRequestInfo(
     {
       domains,
-      publicKeyDer: new Uint8Array<ArrayBuffer>(
-        await crypto.subtle.exportKey("raw", keyPair.publicKey),
+      subjectPKInfo: new Uint8Array<ArrayBuffer>(
+        await crypto.subtle.exportKey("spki", keyPair.publicKey),
       ),
     },
   );
@@ -47,19 +54,20 @@ export async function generateCSR(
     certificationRequestInfoSequence,
     // signatureAlgorithm
     Asn1Encoder.sequence(
-      Asn1Encoder.oid(OIDS.ECDSA_WITH_SHA256),
+      Asn1Encoder.oid(keyPairAlgorithm === "ec" ? OIDS.ECDSA_WITH_SHA256 : OIDS.RSA_WITH_SHA256),
     ),
     // signature
     encodeSignatureBitString(
       await sign(keyPair.privateKey, certificationRequestInfoSequence),
+      keyPairAlgorithm,
     ),
   );
 }
 
 function encodeCertificationRequestInfo(
-  { domains, publicKeyDer }: {
+  { domains, subjectPKInfo }: {
     domains: readonly string[];
-    publicKeyDer: Uint8Array<ArrayBuffer>;
+    subjectPKInfo: Uint8Array<ArrayBuffer>;
   },
 ): Uint8Array<ArrayBuffer> {
   const [mainDomain] = domains;
@@ -89,18 +97,12 @@ function encodeCertificationRequestInfo(
       ),
     ),
     // subjectPKInfo
-    Asn1Encoder.sequence(
-      Asn1Encoder.sequence(
-        Asn1Encoder.oid(OIDS.ID_EC_PUBLIC_KEY),
-        Asn1Encoder.oid(OIDS.PRIME256V1),
-      ),
-      Asn1Encoder.bitString(publicKeyDer),
-    ),
+    subjectPKInfo,
     // attributes
     Asn1Encoder.custom(
       0xA0, // Tag: [0].
       Asn1Encoder.sequence(
-        Asn1Encoder.oid(OIDS.EXTENSION_REQUET),
+        Asn1Encoder.oid(OIDS.EXTENSION_REQUEST),
         Asn1Encoder.set(
           Asn1Encoder.sequence(
             encodeSubjectAlternativeName(domains),
@@ -142,11 +144,15 @@ const encodeSubjectAlternativeName = (() => {
 
 const encodeSignatureBitString = (
   signature: Uint8Array<ArrayBuffer>,
+  keyPairAlgorithm?: KeyPairAlgorithm,
 ): Uint8Array<ArrayBuffer> => {
-  const [r, s] = splitAtIndex(signature, signature.byteLength / 2);
+  if (keyPairAlgorithm === "ec") {
+    const [r, s] = splitAtIndex(signature, signature.byteLength / 2);
 
-  return Asn1Encoder.bitString(Asn1Encoder.sequence(
-    Asn1Encoder.uintBytes(r),
-    Asn1Encoder.uintBytes(s),
-  ));
+    return Asn1Encoder.bitString(Asn1Encoder.sequence(
+      Asn1Encoder.uintBytes(r),
+      Asn1Encoder.uintBytes(s),
+    ));
+  }
+  return Asn1Encoder.bitString(signature);
 };

--- a/src/utils/jws.test.ts
+++ b/src/utils/jws.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "../../test_deps.ts";
+import { decodeBase64Url } from "./base64.ts";
+import { generateKeyPair } from "./crypto.ts";
+import { jws } from "./jws.ts";
+
+const decodeProtectedHeader = (protectedHeader: string) =>
+  JSON.parse(new TextDecoder().decode(decodeBase64Url(protectedHeader)));
+
+describe("jws", () => {
+  it("should pick ES256 for EC keys and RS256 for RSA keys", async () => {
+    for (
+      const [algorithm, expectedAlg] of [
+        ["ec", "ES256"],
+        ["rsa-2048", "RS256"],
+      ] as const
+    ) {
+      const { privateKey } = await generateKeyPair(algorithm);
+      const { protected: protectedHeader } = await jws(privateKey, {
+        protected: { url: "https://example.com" },
+        payload: { hello: "world" },
+      });
+
+      expect(decodeProtectedHeader(protectedHeader).alg).toBe(expectedAlg);
+    }
+  });
+
+  it("should let an explicit alg in the protected header win", async () => {
+    // External Account Binding signs the account key with an HMAC key + HS256,
+    // which has no EC/RSA family. The explicit alg must be used as-is.
+    const hmacKey = await crypto.subtle.importKey(
+      "raw",
+      new Uint8Array(32),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign", "verify"],
+    );
+
+    const { protected: protectedHeader } = await jws(hmacKey, {
+      protected: { alg: "HS256", url: "https://example.com" },
+      payload: { hello: "world" },
+    });
+
+    expect(decodeProtectedHeader(protectedHeader).alg).toBe("HS256");
+  });
+
+  it("should produce a signature that verifies against the public key", async () => {
+    for (
+      const [algorithm, verifyParams] of [
+        ["ec", { name: "ECDSA", hash: "SHA-256" }],
+        ["rsa-2048", { name: "RSASSA-PKCS1-v1_5" }],
+      ] as const
+    ) {
+      const { privateKey, publicKey } = await generateKeyPair(algorithm);
+      const result = await jws(privateKey, {
+        protected: { url: "https://example.com" },
+        payload: { hello: "world" },
+      });
+
+      const verified = await crypto.subtle.verify(
+        verifyParams,
+        publicKey,
+        decodeBase64Url(result.signature),
+        new TextEncoder().encode(`${result.protected}.${result.payload}`),
+      );
+
+      expect(verified).toBe(true);
+    }
+  });
+});

--- a/src/utils/jws.test.ts
+++ b/src/utils/jws.test.ts
@@ -10,7 +10,7 @@ describe("jws", () => {
   it("should pick ES256 for EC keys and RS256 for RSA keys", async () => {
     for (
       const [algorithm, expectedAlg] of [
-        ["ec", "ES256"],
+        ["ec-p256", "ES256"],
         ["rsa-2048", "RS256"],
       ] as const
     ) {
@@ -46,7 +46,7 @@ describe("jws", () => {
   it("should produce a signature that verifies against the public key", async () => {
     for (
       const [algorithm, verifyParams] of [
-        ["ec", { name: "ECDSA", hash: "SHA-256" }],
+        ["ec-p256", { name: "ECDSA", hash: "SHA-256" }],
         ["rsa-2048", { name: "RSASSA-PKCS1-v1_5" }],
       ] as const
     ) {

--- a/src/utils/jws.ts
+++ b/src/utils/jws.ts
@@ -42,7 +42,7 @@ export const jws = async (
 }> => {
   const jwsWithoutSignature = {
     protected: encodeBase64Url(JSON.stringify({
-      alg: "ES256",
+      alg: privateKey.algorithm.name.startsWith("RSA") ? "RS256" : "ES256",
       ...data.protected,
     })),
     payload: data.payload === undefined

--- a/src/utils/jws.ts
+++ b/src/utils/jws.ts
@@ -1,12 +1,20 @@
-import { getKeyAlgorithmFamily, sign } from "../utils/crypto.ts";
+import {
+  getKeyAlgorithmFamily,
+  type KeyAlgorithmFamily,
+  sign,
+} from "../utils/crypto.ts";
 import { encodeBase64Url } from "./base64.ts";
 
 /**
  * The JWS `alg` for each key family: `ES256` for EC P-256, `RS256` for RSA
  * (RFC 7518 §3.3/§3.4). ACME requires a non-MAC `alg` on account requests
- * (RFC 8555 §6.2), which both satisfy.
+ * (RFC 8555 §6.2), which both satisfy. `satisfies` keeps this exhaustive over
+ * every {@link KeyAlgorithmFamily}.
  */
-const JWS_ALG = { ec: "ES256", rsa: "RS256" } as const;
+const JWS_ALG = {
+  ec: "ES256",
+  rsa: "RS256",
+} as const satisfies Record<KeyAlgorithmFamily, string>;
 
 export const jwsFetch = async (url: string, {
   method = "POST",

--- a/src/utils/jws.ts
+++ b/src/utils/jws.ts
@@ -1,6 +1,6 @@
 import {
-  getKeyAlgorithmFamily,
-  type KeyAlgorithmFamily,
+  getKeyPairAlgorithmFamily,
+  type KeyPairAlgorithmFamily,
   sign,
 } from "../utils/crypto.ts";
 import { encodeBase64Url } from "./base64.ts";
@@ -9,12 +9,12 @@ import { encodeBase64Url } from "./base64.ts";
  * The JWS `alg` for each key family: `ES256` for EC P-256, `RS256` for RSA
  * (RFC 7518 §3.3/§3.4). ACME requires a non-MAC `alg` on account requests
  * (RFC 8555 §6.2), which both satisfy. `satisfies` keeps this exhaustive over
- * every {@link KeyAlgorithmFamily}.
+ * every {@link KeyPairAlgorithmFamily}.
  */
-const JWS_ALG = {
+const JWS_ALG_BY_FAMILY = {
   ec: "ES256",
   rsa: "RS256",
-} as const satisfies Record<KeyAlgorithmFamily, string>;
+} as const satisfies Record<KeyPairAlgorithmFamily, string>;
 
 export const jwsFetch = async (url: string, {
   method = "POST",
@@ -58,9 +58,9 @@ export const jws = async (
   // Default the `alg` from the signing key, but let an explicit `alg` in
   // `data.protected` win — e.g. External Account Binding signs with an HMAC
   // key and `HS256`, which has no EC/RSA family. Destructuring defaults are
-  // lazy, so getKeyAlgorithmFamily is never asked about such keys.
+  // lazy, so getKeyPairAlgorithmFamily is never asked about such keys.
   const {
-    alg = JWS_ALG[getKeyAlgorithmFamily(privateKey)],
+    alg = JWS_ALG_BY_FAMILY[getKeyPairAlgorithmFamily(privateKey)],
     ...remainingProtected
   } = data.protected;
 

--- a/src/utils/jws.ts
+++ b/src/utils/jws.ts
@@ -55,14 +55,19 @@ export const jws = async (
   payload: string;
   signature: string;
 }> => {
+  // Default the `alg` from the signing key, but let an explicit `alg` in
+  // `data.protected` win — e.g. External Account Binding signs with an HMAC
+  // key and `HS256`, which has no EC/RSA family. Destructuring defaults are
+  // lazy, so getKeyAlgorithmFamily is never asked about such keys.
+  const {
+    alg = JWS_ALG[getKeyAlgorithmFamily(privateKey)],
+    ...remainingProtected
+  } = data.protected;
+
   const jwsWithoutSignature = {
     protected: encodeBase64Url(JSON.stringify({
-      // Default the `alg` from the signing key, but let an explicit `alg` in
-      // `data.protected` win — e.g. External Account Binding signs with an
-      // HMAC key and `HS256`, which has no EC/RSA family. `??` short-circuits
-      // so getKeyAlgorithmFamily is never asked about such keys.
-      alg: data.protected.alg ?? JWS_ALG[getKeyAlgorithmFamily(privateKey)],
-      ...data.protected,
+      alg,
+      ...remainingProtected,
     })),
     payload: data.payload === undefined
       ? ""

--- a/src/utils/jws.ts
+++ b/src/utils/jws.ts
@@ -49,7 +49,11 @@ export const jws = async (
 }> => {
   const jwsWithoutSignature = {
     protected: encodeBase64Url(JSON.stringify({
-      alg: JWS_ALG[getKeyAlgorithmFamily(privateKey)],
+      // Default the `alg` from the signing key, but let an explicit `alg` in
+      // `data.protected` win — e.g. External Account Binding signs with an
+      // HMAC key and `HS256`, which has no EC/RSA family. `??` short-circuits
+      // so getKeyAlgorithmFamily is never asked about such keys.
+      alg: data.protected.alg ?? JWS_ALG[getKeyAlgorithmFamily(privateKey)],
       ...data.protected,
     })),
     payload: data.payload === undefined

--- a/src/utils/jws.ts
+++ b/src/utils/jws.ts
@@ -1,5 +1,12 @@
-import { sign } from "../utils/crypto.ts";
+import { getKeyAlgorithmFamily, sign } from "../utils/crypto.ts";
 import { encodeBase64Url } from "./base64.ts";
+
+/**
+ * The JWS `alg` for each key family: `ES256` for EC P-256, `RS256` for RSA
+ * (RFC 7518 §3.3/§3.4). ACME requires a non-MAC `alg` on account requests
+ * (RFC 8555 §6.2), which both satisfy.
+ */
+const JWS_ALG = { ec: "ES256", rsa: "RS256" } as const;
 
 export const jwsFetch = async (url: string, {
   method = "POST",
@@ -42,7 +49,7 @@ export const jws = async (
 }> => {
   const jwsWithoutSignature = {
     protected: encodeBase64Url(JSON.stringify({
-      alg: privateKey.algorithm.name.startsWith("RSA") ? "RS256" : "ES256",
+      alg: JWS_ALG[getKeyAlgorithmFamily(privateKey)],
       ...data.protected,
     })),
     payload: data.payload === undefined

--- a/src/utils/object.test.ts
+++ b/src/utils/object.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "../../test_deps.ts";
+import { omit } from "./object.ts";
+
+describe("omit", () => {
+  it("should remove the given keys", () => {
+    expect(omit({ a: 1, b: 2, c: 3 }, ["a", "c"])).toEqual({ b: 2 });
+  });
+
+  it("should ignore keys that are not present", () => {
+    expect(omit({ a: 1 } as { a: number; b?: number }, ["b"])).toEqual({
+      a: 1,
+    });
+  });
+
+  it("should return an empty object when all keys are removed", () => {
+    expect(omit({ a: 1, b: 2 }, ["a", "b"])).toEqual({});
+  });
+
+  it("should not mutate the original object", () => {
+    const original = { a: 1, b: 2 };
+    omit(original, ["a"]);
+    expect(original).toEqual({ a: 1, b: 2 });
+  });
+});

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,16 @@
+/**
+ * Return a shallow copy of `obj` with the given `keys` removed.
+ *
+ * Useful for deriving a public JWK from a private one by dropping the private
+ * members without mutating the original object.
+ */
+export const omit = <T extends object, K extends keyof T>(
+  obj: T,
+  keys: readonly K[],
+): Omit<T, K> => {
+  const result = { ...obj };
+  for (const key of keys) {
+    delete (result as Partial<T>)[key];
+  }
+  return result;
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,34 @@
+/**
+ * @module
+ *
+ * Type-level helpers vendored (with light adaptation) from
+ * {@link https://github.com/sindresorhus/type-fest | type-fest} by Sindre
+ * Sorhus, MIT licensed. Copied rather than depended on to keep this package
+ * zero-dependency.
+ */
+
+/**
+ * All keys across every member of a union.
+ *
+ * `keyof (A | B)` only yields the keys common to all members; this yields the
+ * keys of each member by distributing over the union first.
+ *
+ * @see https://github.com/sindresorhus/type-fest/blob/main/source/keys-of-union.d.ts
+ */
+export type KeysOfUnion<Union> = Union extends unknown ? keyof Union : never;
+
+/**
+ * Widen a union so every member also declares the other members' keys as
+ * `?: never`. Properties can then be read directly off the union — members
+ * that lack a key type it as `undefined` instead of erroring — which makes
+ * unions of structurally different shapes (e.g. `EcKeyAlgorithm |
+ * RsaHashedKeyAlgorithm`) ergonomic to destructure and compare.
+ *
+ * @see https://github.com/sindresorhus/type-fest/blob/main/source/exclusify-union.d.ts
+ */
+export type ExclusifyUnion<
+  Union,
+  Keys extends PropertyKey = KeysOfUnion<Union>,
+> = Union extends unknown
+  ? Union & Partial<Record<Exclude<Keys, keyof Union>, never>>
+  : never;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -18,6 +18,16 @@
 export type KeysOfUnion<Union> = Union extends unknown ? keyof Union : never;
 
 /**
+ * Flatten intersections into a plain object type so editor hovers show
+ * `{ a: string; b?: never }` instead of `EcKeyGenParams & { b?: never }`.
+ * The trailing `& {}` is what forces TypeScript to resolve the mapped type.
+ *
+ * @see https://github.com/sindresorhus/type-fest/blob/main/source/simplify.d.ts
+ */
+// deno-lint-ignore ban-types
+export type Simplify<T> = { [K in keyof T]: T[K] } & {};
+
+/**
  * Widen a union so every member also declares the other members' keys as
  * `?: never`. Properties can then be read directly off the union — members
  * that lack a key type it as `undefined` instead of erroring — which makes
@@ -30,5 +40,5 @@ export type ExclusifyUnion<
   Union,
   Keys extends PropertyKey = KeysOfUnion<Union>,
 > = Union extends unknown
-  ? Union & Partial<Record<Exclude<Keys, keyof Union>, never>>
+  ? Simplify<Union & Partial<Record<Exclude<Keys, keyof Union>, never>>>
   : never;


### PR DESCRIPTION
Builds on #39 by @unilynx (original commit preserved as-is for credit), then layers a refactor + fixes on top.

## Why

#39 adds RSA support by threading an optional `keyPairAlgorithm` hint through the CSR/JWS paths and branching on it inline (`=== "ec"`, `startsWith("RSA")`). Because the hint is optional and defaults to `undefined`, the CSR code treats the **default EC path** (used by every account created without specifying an algorithm) as RSA:

- it labels the CSR `sha256WithRSAEncryption` over an EC key, and
- emits the raw `r‖s` bytes instead of the DER `SEQUENCE { r, s }` that ECDSA requires.

The result is an invalid CSR that CAs reject. This is reproducible against `openssl` and breaks the existing `generateCSR` unit tests:

```
- Signature Algorithm: sha256WithRSAEncryption
+ Signature Algorithm: ecdsa-with-SHA256
```

## What changed

**Resolve the algorithm from the key, not a separate hint.** A `CryptoKey` already knows whether it's EC or RSA, so `getKeyAlgorithmFamily(key)` becomes the single source of truth. The JWS `alg` and the CSR `signatureAlgorithm`/signature encoding can no longer disagree with the actual key material, which removes the bug by construction. The per-family behaviour now lives in one strategy table instead of scattered conditionals.

- `generateCSR` derives the family from `keyPair` and no longer takes a `keyPairAlgorithm` param.
- `jws` selects `ES256`/`RS256` from the same resolver.
- RSA `signatureAlgorithm` now carries the explicit **NULL** parameters required by RFC 4055 §5 (added `Asn1Encoder.null()`); EC keeps absent parameters per RFC 5758.
- `importKeyPairFromPemPrivateKey` strips **all** private JWK members (not just `d` — RSA also exposes `p, q, dp, dq, qi`) and derives the public key from the private key's own algorithm, so RSA PEM import is correct across runtimes.
- `keyPairAlgorithm` is now applied consistently: to the account key in `createAccount` and preserved across `keyRollover` (previously it was ignored at creation but honoured on rollover).
- Exported the public `KeyPairAlgorithm` type from `mod.ts`.

## Spec verification

Checked against RFC 8555 (ACME), RFC 7518 (JWS `alg`), RFC 2986/5280 (CSR), RFC 3279/5758/4055 (signature AlgorithmIdentifier + ECDSA `r,s` encoding). Switching `subjectPKInfo` to the WebCrypto `spki` export (from #39) is the correct standard encoding for both key types.

## Tests

- Added RSA + RSA-4096 CSR tests (openssl re-verifies the self-signature).
- Added an RSA PEM export→import→export round-trip test.
- Added an explicit "default to ECDSA CSR" regression guard.
- Local run is green: `deno fmt --check`, `deno lint`, `deno check --doc .`, `deno task test:unit` (23 passed), and `deno task build:npm:unit` (Node). Integration (Pebble) was not run locally and will run in CI.

## Review round 2

A follow-up review of this PR surfaced one more critical bug plus several smaller items; all are fixed in the three newest commits:

- **RSA account keys couldn't pass any challenge.** `getJWKThumbprint` hardcoded the EC JWK members (`crv, kty, x, y`), so an RSA key canonicalized to `{"kty":"RSA"}` and every dns-01/http-01 key authorization was rejected (Pebble: `Correct value not found for DNS challenge`). It now selects the RFC 7638 §3.2 required members by key type (`{e, kty, n}` for RSA). Caught by the new RSA end-to-end integration test, which is included along with a unit regression test.
- **Non-minimal DER INTEGERs** (pre-existing): WebCrypto zero-pads ECDSA `r`/`s` to 32 bytes and `Asn1Encoder.uintBytes` kept the leading zeros, so ~1 in 128 EC CSR signatures were invalid strict DER. INTEGERs are now encoded minimally.
- `login()` derives `keyPairAlgorithm` from the given key pair when omitted, so an RSA account keeps minting RSA certificate keys instead of silently falling back to EC.
- `importKeyPairFromPemPrivateKey` detects the algorithm from the PKCS#8 AlgorithmIdentifier and drops its `keyPairAlgorithm` parameter; non-P-256 curves and unknown algorithms fail with clear errors.
- Also: the multi-prime `oth` JWK member is stripped too, an explicit `alg: undefined` can no longer erase the JWS `alg`, and `keyPairAlgorithm` is now documented in the README and the `createAccount`/`login` docstrings.

Verified locally this round: `deno fmt --check`, `deno lint`, `deno check --doc .`, unit tests on Deno (31 passed) and Node 25 (via dnt), and the **full Pebble integration suite (7 passed)** including the new RSA certificate issuance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9SJB9Kcj4xBBujmYB6ZzK

https://claude.ai/code/session_01GiEjjgiAJJiSg7UgUythVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9SJB9Kcj4xBBujmYB6ZzK)_


---
<a href="https://app.blacksmith.sh/fishballapp/codesmith/acme/pr/41" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"&gt;``</a> <a href="``https://backend.blacksmith.sh/track/enable-autofix?expires=1784887169&amp;installation_id=142134082&amp;pr_number=41&amp;repository=fishballapp%2Facme&amp;return_to=https%3A%2F%2Fgithub.com%2Ffishballapp%2Facme%2Fpull%2F41&amp;signature=b1f4f5bd1e8a3f5a09682e76c5febbe3e083043ea0017067e58da9e97a3b8919"`` rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"&gt;``</a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>