### PR TITLE
fix(ci): repair Publish workflow (JSR slow types + npm provenance runner)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,9 @@ jobs:
       - run: deno fmt --check
       - run: deno lint
       - run: deno check --doc .
+      # Catch JSR "slow types" and packaging errors on PRs — the real
+      # `jsr publish` only runs on main, too late to block a bad merge.
+      - run: deno publish --dry-run
   deno-unit:
     name: "Unit Test (Deno)"
     runs-on: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,9 +4,13 @@ on:
     branches:
       - main
 
+# NOTE: these jobs stay on GitHub-hosted runners. `npm publish --provenance`
+# (and JSR's OIDC provenance) require a "github-hosted" runner — npm rejects
+# provenance from Blacksmith's self-hosted runners with a 422. Publish runs
+# only on release, so keeping it here costs effectively no CI quota.
 jobs:
   publish-jsr:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -19,7 +23,7 @@ jobs:
         run: npx jsr publish
 
   publish-npm:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -61,10 +61,15 @@ export type KeyPairAlgorithm = "ec-p256" | "rsa-2048" | "rsa-4096";
 
 /**
  * The WebCrypto parameters used to generate each supported key algorithm.
+ *
+ * The value type is {@link ExclusifyUnion}'d so that reading a member another
+ * family lacks (e.g. `.modulusLength` off the EC entry) types as `undefined`
+ * rather than erroring — which is what lets {@link deriveKeyPairAlgorithm}
+ * compare every field uniformly without narrowing first.
  */
 const KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM: Record<
   KeyPairAlgorithm,
-  EcKeyGenParams | RsaHashedKeyGenParams
+  ExclusifyUnion<EcKeyGenParams | RsaHashedKeyGenParams>
 > = {
   "ec-p256": {
     name: WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY.ec,
@@ -117,8 +122,7 @@ export function deriveKeyPairAlgorithm(
     KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM,
   ) as KeyPairAlgorithm[]).find(
     (keyPairAlgorithm) => {
-      const params: ExclusifyUnion<EcKeyGenParams | RsaHashedKeyGenParams> =
-        KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM[keyPairAlgorithm];
+      const params = KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM[keyPairAlgorithm];
       // Members a family lacks are `undefined` on both sides (see
       // ExclusifyUnion), so the same equalities cover EC (namedCurve)
       // and RSA (modulusLength) alike.

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -45,11 +45,27 @@ export type KeyPairAlgorithmFamily =
   keyof typeof WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY;
 
 /**
- * The WebCrypto parameters used to generate each supported key algorithm. Its
- * keys are the source of truth for {@link KeyPairAlgorithm}; `satisfies`
- * validates every entry without widening the literal types away.
+ * The key algorithm used for an account's keys and the certificate keys it
+ * mints.
+ *
+ * - `ec-p256`: ECDSA on the NIST P-256 curve (signed as `ES256`). The default.
+ * - `rsa-2048`: RSASSA-PKCS1-v1_5 with a 2048-bit modulus (signed as `RS256`).
+ * - `rsa-4096`: as `rsa-2048`, but with a 4096-bit modulus.
+ *
+ * Spelled as an explicit union rather than `keyof typeof
+ * KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM`: JSR forbids inferred types in the
+ * public API ("slow types"), and the `Record<KeyPairAlgorithm, …>` on that
+ * table keeps the two in sync — a missing or extra entry fails to compile.
  */
-const KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM = {
+export type KeyPairAlgorithm = "ec-p256" | "rsa-2048" | "rsa-4096";
+
+/**
+ * The WebCrypto parameters used to generate each supported key algorithm.
+ */
+const KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM: Record<
+  KeyPairAlgorithm,
+  EcKeyGenParams | RsaHashedKeyGenParams
+> = {
   "ec-p256": {
     name: WEB_CRYPTO_ALGORITHM_NAME_BY_FAMILY.ec,
     namedCurve: "P-256",
@@ -66,18 +82,7 @@ const KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM = {
     publicExponent: RSA_PUBLIC_EXPONENT,
     hash: "SHA-256",
   },
-} as const satisfies Record<string, EcKeyGenParams | RsaHashedKeyGenParams>;
-
-/**
- * The key algorithm used for an account's keys and the certificate keys it
- * mints.
- *
- * - `ec-p256`: ECDSA on the NIST P-256 curve (signed as `ES256`). The default.
- * - `rsa-2048`: RSASSA-PKCS1-v1_5 with a 2048-bit modulus (signed as `RS256`).
- * - `rsa-4096`: as `rsa-2048`, but with a 4096-bit modulus.
- */
-export type KeyPairAlgorithm =
-  keyof typeof KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM;
+};
 
 /** Map a key's reported WebCrypto `algorithm.name` back to its family. */
 const FAMILY_BY_WEB_CRYPTO_ALGORITHM_NAME: Record<


### PR DESCRIPTION
The `Publish` workflow failed on `main` after #41 merged, so `0.18.0` did not ship to either registry. This restores it.

## What broke

Two independent failures on the merge commit:

1. **`publish-jsr`** — `jsr publish` rejected the public API for a "slow type":

   ```
   error[missing-explicit-type]: missing explicit type in the public API
    --> src/utils/crypto.ts:52:7
   52 | const KEY_GEN_PARAMS_BY_KEY_PAIR_ALGORITHM = {
   ```

   The exported `KeyPairAlgorithm` was `keyof typeof` a `const` whose values include `Uint8Array`s, which JSR cannot cheaply represent. This only surfaced now because `jsr publish` runs on `main` only — PR CI never exercised it.

2. **`publish-npm`** — `npm publish --provenance` returned `422`:

   ```
   Error verifying sigstore provenance bundle: Unsupported GitHub Actions
   runner environment: "self-hosted". Only "github-hosted" runners are
   supported when publishing with provenance.
   ```

   The Blacksmith runner migration moved the publish jobs onto self-hosted runners, which npm's provenance flow rejects.

Neither registry stored `0.18.0` (JSR failed before publishing; npm's `422` rejected the upload), so the version is still available on both — merging this re-triggers the workflow and ships `0.18.0` cleanly.

## Changes

- **`src/utils/crypto.ts`** — spell `KeyPairAlgorithm` as an explicit union (`"ec-p256" | "rsa-2048" | "rsa-4096"`) and type the table as `Record<KeyPairAlgorithm, …>` instead of inferring the type back from the table. The `Record` keeps the two in sync — a missing or extra entry fails to compile — so nothing is lost.
- **`.github/workflows/publish.yaml`** — move both publish jobs back to `ubuntu-latest`, with a comment explaining that provenance requires a github-hosted runner. `ci`, `integration`, and `e2e` stay on Blacksmith. Publish runs only on release, so the quota cost is negligible.
- **`.github/workflows/ci.yaml`** — add `deno publish --dry-run` to the check job so JSR slow-type and packaging errors are caught on PRs, rather than post-merge when it is too late to block a bad merge.

## Verification

Locally (Deno + Node 25): `deno fmt --check`, `deno lint`, `deno check --doc .`, **`deno publish --dry-run` → Success**, `deno task test:unit` (32 passed), and `deno task build:npm:unit`. CI now runs the same dry-run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiEjjgiAJJiSg7UgUythVj)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishballapp/codesmith/acme/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786542806&installation_id=142134082&pr_number=42&repository=fishballapp%2Facme&return_to=https%3A%2F%2Fgithub.com%2Ffishballapp%2Facme%2Fpull%2F42&signature=4c315695c14b781b03a61d9b1f1a22d1f4be407a6601c5a03ded160142bada5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->