### PR TITLE
fix(e2e): resolve challenge TXT via DoH so E2E works on Blacksmith

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,6 +13,15 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+        with:
+          # `pull_request_target` runs in the base-repo context and, with a bare
+          # checkout, checks out the base branch (`main`) rather than the PR head
+          # -- so a labeled run would test `main`'s code, not the PR's. Check out
+          # the PR head SHA so the E2E actually exercises the PR. This is gated by
+          # the `e2e:approve` label above: a maintainer must approve the PR before
+          # its code runs here with secrets. For `push` events this expression is
+          # empty and checkout falls back to the pushed ref (`main`).
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x # Run with latest stable Deno.

--- a/e2e/create-certificate.test.ts
+++ b/e2e/create-certificate.test.ts
@@ -6,7 +6,7 @@ import {
   AcmeOrder,
   DnsUtils,
 } from "../src/mod.ts";
-import { resolveDns } from "./utils/resolveDns.ts";
+import { resolveDns, waitForDnsPropagation } from "./utils/resolveDns.ts";
 import { expect, it } from "../test_deps.ts";
 import { CloudflareZone } from "./utils/cloudflare.ts";
 import { expectToBeDefined } from "./utils/expectToBeDefined.ts";
@@ -52,6 +52,8 @@ it("can talk to ACME server and successfully create an account, order then all t
     content: expectedRecord.content,
   }]);
   console.log("⏳ Creating DNS record for _acme-challenge...");
+
+  await waitForDnsPropagation();
 
   await DnsUtils.pollDnsTxtRecord(expectedRecord.name, {
     pollUntil: expectedRecord.content,

--- a/e2e/create-certificate.test.ts
+++ b/e2e/create-certificate.test.ts
@@ -6,7 +6,7 @@ import {
   AcmeOrder,
   DnsUtils,
 } from "../src/mod.ts";
-import { resolveDns } from "../src/resolveDns.deno.ts";
+import { resolveDns } from "./utils/resolveDns.ts";
 import { expect, it } from "../test_deps.ts";
 import { CloudflareZone } from "./utils/cloudflare.ts";
 import { expectToBeDefined } from "./utils/expectToBeDefined.ts";

--- a/e2e/utils/resolveDns.ts
+++ b/e2e/utils/resolveDns.ts
@@ -1,18 +1,54 @@
 import { createResolveDns, PUBLIC_DNS } from "@fishballpkg/acme/resolveDns.doh";
+import type { ResolveDnsFunction } from "@fishballpkg/acme/DnsUtils";
 
 /**
  * E2E resolver used to poll for challenge TXT records.
  *
- * We deliberately resolve over DNS-over-HTTPS rather than the default
- * `Deno.resolveDns` (see `../../src/resolveDns.deno.ts`). E2E runs on
- * Blacksmith's Firecracker microVMs, whose local resolver answers `fetch`'s
- * hostname lookups but returns nothing for the external TXT queries that
- * `Deno.resolveDns` issues directly over UDP/53 — so the challenge poll would
- * never see the record and time out. DoH resolves over HTTPS (the same path
- * `fetch` already uses successfully here), so it is independent of the
- * runner's local DNS. It is also a stronger propagation signal: a real public
- * recursive resolver rather than the CI box's resolver.
+ * Two things are going on here:
+ *
+ * 1. **DoH instead of `Deno.resolveDns`.** E2E runs on Blacksmith's Firecracker
+ *    microVMs, whose local resolver can't answer the external TXT queries
+ *    `Deno.resolveDns` issues directly over UDP/53. DoH resolves over HTTPS —
+ *    the same path `fetch` already uses successfully here.
+ *
+ * 2. **Rotating across public resolvers.** A recursive resolver that is asked
+ *    for the freshly-created `_acme-challenge` record *before* it has
+ *    propagated caches the `NXDOMAIN` for the zone's SOA negative-TTL
+ *    (`fishball.dev` = 1800s), which is far longer than the 10-minute poll — so
+ *    a single early miss would otherwise poison the whole run. Rotating means a
+ *    negative cached at one resolver on an early attempt can't sink the poll:
+ *    the next attempt hits a different resolver whose first lookup lands after
+ *    propagation. {@link waitForDnsPropagation} additionally holds off the very
+ *    first query until the record is live, so ideally no negative is ever
+ *    cached.
+ *
+ *    Only Cloudflare and Google are used: they implement the DoH JSON API this
+ *    resolver speaks. Quad9's `/dns-query` answers `application/dns-json` with
+ *    `400`, which would throw and — since {@link pollDnsTxtRecord} surfaces
+ *    thrown errors immediately — fail the poll rather than retry.
  */
-export const resolveDns = createResolveDns({
-  endpoint: PUBLIC_DNS.cloudflare.doh[0],
-});
+const resolvers: readonly ResolveDnsFunction[] = [
+  createResolveDns({ endpoint: PUBLIC_DNS.cloudflare.doh[0] }),
+  createResolveDns({ endpoint: PUBLIC_DNS.google.doh[0] }),
+];
+
+let attempt = 0;
+export const resolveDns: ResolveDnsFunction = (query, recordType) => {
+  const resolver = resolvers[attempt % resolvers.length]!;
+  attempt++;
+  return resolver(query, recordType);
+};
+
+/**
+ * Delay (ms) to let a just-created record reach the public recursive resolvers
+ * before the first lookup. Comfortably exceeds Cloudflare's API→resolver
+ * propagation (seconds) while staying well under the 10-minute poll budget.
+ */
+const DNS_PROPAGATION_DELAY = 30_000;
+
+/**
+ * Wait for a just-created record to propagate before the first DNS lookup, so
+ * the poll never caches a negative answer (see {@link resolveDns}).
+ */
+export const waitForDnsPropagation = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, DNS_PROPAGATION_DELAY));

--- a/e2e/utils/resolveDns.ts
+++ b/e2e/utils/resolveDns.ts
@@ -1,0 +1,18 @@
+import { createResolveDns, PUBLIC_DNS } from "@fishballpkg/acme/resolveDns.doh";
+
+/**
+ * E2E resolver used to poll for challenge TXT records.
+ *
+ * We deliberately resolve over DNS-over-HTTPS rather than the default
+ * `Deno.resolveDns` (see `../../src/resolveDns.deno.ts`). E2E runs on
+ * Blacksmith's Firecracker microVMs, whose local resolver answers `fetch`'s
+ * hostname lookups but returns nothing for the external TXT queries that
+ * `Deno.resolveDns` issues directly over UDP/53 — so the challenge poll would
+ * never see the record and time out. DoH resolves over HTTPS (the same path
+ * `fetch` already uses successfully here), so it is independent of the
+ * runner's local DNS. It is also a stronger propagation signal: a real public
+ * recursive resolver rather than the CI box's resolver.
+ */
+export const resolveDns = createResolveDns({
+  endpoint: PUBLIC_DNS.cloudflare.doh[0],
+});

--- a/e2e/wildcard.test.ts
+++ b/e2e/wildcard.test.ts
@@ -5,7 +5,7 @@ import {
   AcmeOrder,
   DnsUtils,
 } from "../src/mod.ts";
-import { resolveDns } from "./utils/resolveDns.ts";
+import { resolveDns, waitForDnsPropagation } from "./utils/resolveDns.ts";
 import { expect, it } from "../test_deps.ts";
 import { CloudflareZone } from "./utils/cloudflare.ts";
 import { expectToBeDefined } from "./utils/expectToBeDefined.ts";
@@ -62,6 +62,8 @@ it("can talk to ACME server and successfully retrieve a wildcard certificate", a
   // Create DNS records (likely 2 TXT records on the same name)
   await cloudflareZone.createDnsRecords(dnsTxtRecords);
   console.log("⏳ Creating DNS records for _acme-challenge...");
+
+  await waitForDnsPropagation();
 
   await DnsUtils.pollDnsTxtRecord(`_acme-challenge.${DOMAIN}.`, {
     pollUntil: dnsTxtRecords.map(({ content }) => content),

--- a/e2e/wildcard.test.ts
+++ b/e2e/wildcard.test.ts
@@ -5,7 +5,7 @@ import {
   AcmeOrder,
   DnsUtils,
 } from "../src/mod.ts";
-import { resolveDns } from "../src/resolveDns.deno.ts";
+import { resolveDns } from "./utils/resolveDns.ts";
 import { expect, it } from "../test_deps.ts";
 import { CloudflareZone } from "./utils/cloudflare.ts";
 import { expectToBeDefined } from "./utils/expectToBeDefined.ts";

--- a/e2e/workflows.test.ts
+++ b/e2e/workflows.test.ts
@@ -4,7 +4,7 @@ import {
   AcmeOrder,
   AcmeWorkflows,
 } from "@fishballpkg/acme";
-import { resolveDns } from "@fishballpkg/acme/resolveDns.deno";
+import { resolveDns } from "./utils/resolveDns.ts";
 import { describe, expect, it } from "../test_deps.ts";
 import { CloudflareZone } from "./utils/cloudflare.ts";
 import { randomFishballTestingSubdomain } from "./utils/randomFishballTestingSubdomain.ts";

--- a/e2e/workflows.test.ts
+++ b/e2e/workflows.test.ts
@@ -4,7 +4,7 @@ import {
   AcmeOrder,
   AcmeWorkflows,
 } from "@fishballpkg/acme";
-import { resolveDns } from "./utils/resolveDns.ts";
+import { resolveDns, waitForDnsPropagation } from "./utils/resolveDns.ts";
 import { describe, expect, it } from "../test_deps.ts";
 import { CloudflareZone } from "./utils/cloudflare.ts";
 import { randomFishballTestingSubdomain } from "./utils/randomFishballTestingSubdomain.ts";
@@ -35,6 +35,9 @@ describe("requestCertificates", () => {
       domains: DOMAINS,
       updateDnsRecords: async (dnsRecords) => {
         await cloudflareZone.createDnsRecords(dnsRecords);
+        // requestCertificate awaits this callback before it starts polling,
+        // so waiting here holds off the first lookup until the record is live.
+        await waitForDnsPropagation();
       },
       resolveDns,
     });


### PR DESCRIPTION
Follow-up to #41 / #42. The `E2E` workflow has failed on `main` since the Blacksmith runner migration. This keeps E2E on Blacksmith and fixes the cause instead of moving the job back to a GitHub-hosted runner.

## Layer 0 — the labeled run never tested the PR's code

The `E2E` workflow triggers on `pull_request_target` (so labeled PRs from the base-repo context can use the Cloudflare secrets). Under `pull_request_target`, a bare `actions/checkout` checks out the **base branch (`main`)**, not the PR head. So every labeled E2E run tested `main`'s old `Deno.resolveDns` code path and timed out, no matter what the PR branch contained — and re-adding the `e2e:approve` label just re-ran `main`.

Fix: check out the PR head SHA so a labeled run exercises the PR's code. This stays gated by the `e2e:approve` label, so a maintainer must approve the PR before its code runs here with secrets. On `push` to `main` the expression is empty and checkout falls back to the pushed ref.

```yaml
- uses: actions/checkout@v6
  with:
    ref: ${{ github.event.pull_request.head.sha }}
```

## Layer 1 — transport: `Deno.resolveDns` doesn't work in the microVM

`fetch()` and `Deno.resolveDns()` use different DNS paths. `fetch()` uses the OS resolver (works on Blacksmith). `Deno.resolveDns()` bypasses it and sends queries directly over UDP/53 to the resolver in `/etc/resolv.conf`. Blacksmith runs each job in a Firecracker microVM whose local resolver answers `fetch`'s hostname lookups but returns nothing for the external TXT queries `Deno.resolveDns` issues — so the challenge poll never saw the record.

Fix: resolve over **DNS-over-HTTPS** (`@fishballpkg/acme/resolveDns.doh`), which goes over HTTPS/443 — the same path `fetch` already uses successfully.

## Layer 2 — caching: DNS negative-cache trap

Switching to DoH exposed a second problem. The poll queried the freshly-created `_acme-challenge` name *immediately*, racing propagation. When the recursive resolver behind DoH gets that premature query it caches the `NXDOMAIN` for the zone's **SOA negative-TTL — `fishball.dev`'s is 1800s (measured)** — which is 3× the 10-minute poll. So every subsequent lookup returned the stale empty answer and the test timed out, even though the record was live in Cloudflare (visible in the dashboard).

This matches the observed failure exactly: `✅ DNS records created`, then `Received DNS records:` blank on every poll, then timeout.

Fix:

- `waitForDnsPropagation()` (30s) before the first lookup in all three tests, so the record is live before any query and no negative is ever cached. In the workflow test the wait lives at the end of the awaited `updateDnsRecords` callback, which `requestCertificate` awaits before polling.
- `resolveDns` **rotates across Cloudflare and Google DoH**, so a negative cached at one resolver on an early attempt can't sink the whole poll — a later attempt hits a different resolver whose first lookup lands after propagation. Quad9 is intentionally excluded: its `/dns-query` returns `400` for the DoH JSON API, and `pollDnsTxtRecord` surfaces thrown errors immediately.

E2E stays on Blacksmith.

## Evidence

- The failing run (`29320715460`) is a `pull_request_target` run whose GitHub `headSha` is the PR head, but whose checkout log shows `git checkout --force -B main refs/remotes/origin/main` — i.e. it ran `main`, which still imports `resolveDns` from `src/resolveDns.deno.ts`.
- E2E last passed on `66b5090` (ubuntu-latest); failed on every run since `ec9fad2` (first Blacksmith run). Integration passes on Blacksmith (local Docker DNS, no external resolution).
- Reproduced: in a comparable sandboxed microVM, `Deno.resolveDns("cloudflare.com","TXT")` times out while DoH returns all 26 TXT records.
- Measured the trap: `fishball.dev` SOA MINIMUM = `1800`, and the `NXDOMAIN` Authority SOA carries `TTL=1800` → 30-minute negative cache vs a 10-minute poll.
- Verified Cloudflare and Google answer the DoH JSON API (26 TXT records each); Quad9 returns `400`.

## Verifying

E2E only runs on `push` to `main` or a PR labeled `e2e:approve`. To run it on the latest commit, **remove and re-add the `e2e:approve` label** (a fresh `labeled` event is required). With the Layer-0 fix, the labeled run now checks out the PR head and actually exercises this branch's code.
