### PR TITLE
fix(e2e): resolve DNS-01 records against authoritative nameservers

### DIFF
--- a/e2e/create-certificate.test.ts
+++ b/e2e/create-certificate.test.ts
@@ -6,8 +6,8 @@ import {
   AcmeOrder,
   DnsUtils,
 } from "../src/mod.ts";
-import { resolveDns } from "../src/resolveDns.deno.ts";
 import { expect, it } from "../test_deps.ts";
+import { createAuthoritativeResolveDns } from "./utils/authoritativeResolveDns.ts";
 import { CloudflareZone } from "./utils/cloudflare.ts";
 import { expectToBeDefined } from "./utils/expectToBeDefined.ts";
 import { randomFishballTestingSubdomain } from "./utils/randomFishballTestingSubdomain.ts";
@@ -16,6 +16,7 @@ const EMAIL = "e2e@test.acme.pkg.fishball.dev";
 const DOMAIN = randomFishballTestingSubdomain();
 
 const cloudflareZone = await CloudflareZone.init();
+const resolveDns = await createAuthoritativeResolveDns(DOMAIN);
 
 it("can talk to ACME server and successfully create an account, order then all the way to retrieve the certificate for 1 domain", async () => {
   const acmeClient = await AcmeClient.init(

--- a/e2e/utils/authoritativeResolveDns.ts
+++ b/e2e/utils/authoritativeResolveDns.ts
@@ -1,0 +1,66 @@
+// deno-lint-ignore no-unused-vars -- imported for jsdoc
+import type { DnsUtils } from "../../src/mod.ts";
+
+import {
+  createUnanimousResolveDns,
+  type ResolveDnsFunction,
+} from "../../src/DnsUtils/mod.ts";
+import { createResolveDns, resolveDns } from "../../src/resolveDns.deno.ts";
+
+/**
+ * Find the authoritative nameserver hostnames for `domain` by walking up its
+ * labels until a level answers with `NS` records (the zone cut).
+ */
+const resolveZoneNameServers = async (domain: string): Promise<string[]> => {
+  const labels = domain.replace(/\.$/, "").split(".");
+
+  // Stop before the TLD; a registrable zone always has at least two labels.
+  for (let i = 0; i < labels.length - 1; i++) {
+    const candidate = labels.slice(i).join(".");
+    const nameServers = await resolveDns(candidate, "NS");
+    if (nameServers.length > 0) return nameServers;
+  }
+
+  throw new Error(`Could not find authoritative nameservers for "${domain}"`);
+};
+
+/**
+ * Build a resolver that queries the authoritative nameservers of `domain`'s
+ * zone directly, instead of going through a recursive/caching resolver.
+ *
+ * DNS-01 self-checks (see {@link DnsUtils.pollDnsTxtRecord}) poll for a `TXT`
+ * record right after creating it. A recursive resolver (e.g. `1.1.1.1`) caches
+ * the "not found" answer it gets before the record has propagated for the
+ * zone's negative-cache TTL (the SOA minimum, e.g. 1800s for `fishball.dev`).
+ * That TTL outlives the poll timeout, so once a negative answer is cached the
+ * poll can never observe the record and eventually times out — the source of
+ * the flaky E2E failures.
+ *
+ * Authoritative servers do not cache, so they always reflect the current
+ * record. Requiring all of them to agree (via
+ * {@link createUnanimousResolveDns}) additionally guarantees the record is
+ * fully propagated before we ask the CA to validate it.
+ */
+export const createAuthoritativeResolveDns = async (
+  domain: string,
+): Promise<ResolveDnsFunction> => {
+  const nameServers = await resolveZoneNameServers(domain);
+
+  const ipAddrs = [
+    ...new Set(
+      (await Promise.all(
+        nameServers.map((nameServer) => resolveDns(nameServer, "A")),
+      )).flat(),
+    ),
+  ];
+
+  if (ipAddrs.length === 0) {
+    throw new Error(
+      `Could not resolve any authoritative nameserver IP for "${domain}"`,
+    );
+  }
+
+  return createUnanimousResolveDns(
+    ipAddrs.map((ipAddr) => createResolveDns({ nameServer: { ipAddr } })),
+  );
+};

--- a/e2e/utils/randomFishballTestingSubdomain.ts
+++ b/e2e/utils/randomFishballTestingSubdomain.ts
@@ -1,4 +1,4 @@
-const FISHBALL_SUBDOMAIN = "test.acme.pkg.fishball.dev";
+export const FISHBALL_SUBDOMAIN = "test.acme.pkg.fishball.dev";
 
 export const randomFishballTestingSubdomain = () => {
   return `${crypto.randomUUID()}.${FISHBALL_SUBDOMAIN}`.toLowerCase();

--- a/e2e/wildcard.test.ts
+++ b/e2e/wildcard.test.ts
@@ -5,8 +5,8 @@ import {
   AcmeOrder,
   DnsUtils,
 } from "../src/mod.ts";
-import { resolveDns } from "../src/resolveDns.deno.ts";
 import { expect, it } from "../test_deps.ts";
+import { createAuthoritativeResolveDns } from "./utils/authoritativeResolveDns.ts";
 import { CloudflareZone } from "./utils/cloudflare.ts";
 import { expectToBeDefined } from "./utils/expectToBeDefined.ts";
 import { randomFishballTestingSubdomain } from "./utils/randomFishballTestingSubdomain.ts";
@@ -15,6 +15,7 @@ const EMAIL = "e2e-wildcard@test.acme.pkg.fishball.dev";
 const DOMAIN = randomFishballTestingSubdomain(); // e.g., "abc.fishball-testing.dev"
 
 const cloudflareZone = await CloudflareZone.init();
+const resolveDns = await createAuthoritativeResolveDns(DOMAIN);
 
 it("can talk to ACME server and successfully retrieve a wildcard certificate", async () => {
   const acmeClient = await AcmeClient.init(

--- a/e2e/workflows.test.ts
+++ b/e2e/workflows.test.ts
@@ -4,10 +4,13 @@ import {
   AcmeOrder,
   AcmeWorkflows,
 } from "@fishballpkg/acme";
-import { resolveDns } from "@fishballpkg/acme/resolveDns.deno";
 import { describe, expect, it } from "../test_deps.ts";
+import { createAuthoritativeResolveDns } from "./utils/authoritativeResolveDns.ts";
 import { CloudflareZone } from "./utils/cloudflare.ts";
-import { randomFishballTestingSubdomain } from "./utils/randomFishballTestingSubdomain.ts";
+import {
+  FISHBALL_SUBDOMAIN,
+  randomFishballTestingSubdomain,
+} from "./utils/randomFishballTestingSubdomain.ts";
 
 const EMAIL = "e2e@test.acme.pkg.fishball.dev";
 const DOMAINS = [
@@ -17,6 +20,7 @@ const DOMAINS = [
 ];
 
 const cloudflareZone = await CloudflareZone.init();
+const resolveDns = await createAuthoritativeResolveDns(FISHBALL_SUBDOMAIN);
 
 describe("requestCertificates", () => {
   it("should successfully get the certs for the given domains", async () => {


### PR DESCRIPTION
## Why

The `E2E` workflow's `build` job is flaky: it usually passes in ~150s but intermittently fails after ~30 min with three `TimeoutError: Giving up on polling dns txt record` failures (one per E2E test), e.g. run [29257606451](https://github.com/fishballapp/acme/actions/runs/29257606451/job/86841995779). Recent `main` history shows the same job both succeeding (~151s) and timing out (~1814s = 3 × the 10‑min poll timeout).

## Root cause

The E2E DNS‑01 tests create a TXT record via the Cloudflare API and then poll for it with `DnsUtils.pollDnsTxtRecord`, using the default Deno resolver (`resolveDns.deno`). That resolver goes through a recursive/caching resolver (`1.1.1.1`, per the runner's `/etc/resolv.conf`).

When the first poll query races ahead of record propagation, the recursive resolver caches the negative (NXDOMAIN/NODATA) answer for the zone's negative‑cache TTL. `fishball.dev`'s SOA minimum is **1800s (30 min)**:

```
fishball.dev. 1800 IN SOA audrey.ns.cloudflare.com. dns.cloudflare.com. ... 1800
```

`pollDnsTxtRecord`'s timeout is only **600s (10 min)**, so once a negative answer is cached the poll can never observe the record and times out. Each of the three E2E test files hits this independently, which matches the ~30‑min total failure duration. This is why the job is flaky rather than consistently broken: it only fails when the first query loses the race with propagation.

## Fix

Resolve DNS‑01 records against the zone's **authoritative** nameservers directly instead of a recursive/caching resolver. Authoritative servers don't cache, so they always reflect the current record and there's no negative‑cache poisoning. A new `e2e/utils/authoritativeResolveDns.ts` builds this resolver from the library's own primitives:

```ts
export const createAuthoritativeResolveDns = async (
  domain: string,
): Promise<ResolveDnsFunction> => {
  const nameServers = await resolveZoneNameServers(domain); // walk up to the zone cut, e.g. fishball.dev NS
  const ipAddrs = [...new Set(
    (await Promise.all(nameServers.map((ns) => resolveDns(ns, "A")))).flat(),
  )];
  return createUnanimousResolveDns(
    ipAddrs.map((ipAddr) => createResolveDns({ nameServer: { ipAddr } })),
  );
};
```

Using `createUnanimousResolveDns` across every authoritative NS also means the poll only succeeds once all of them serve the record, so the record is fully propagated before the challenge is submitted to the CA. All three E2E tests now use this resolver.

This is test/CI-only; nothing under `src/` (the published package) changes.

## Validation

`deno fmt --check`, `deno lint`, and `deno check e2e/` all pass. The authoritative-resolver approach was verified against the live `fishball.dev` nameservers: it returns existing TXT records and returns `[]` (no throw) for missing names.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishballapp/codesmith/acme/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->